### PR TITLE
refresh subscriptions on receiving userUpdate as well

### DIFF
--- a/custom_components/onlycat/__init__.py
+++ b/custom_components/onlycat/__init__.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.SELECT]
 _LOGGER = logging.getLogger(__name__)
 
+
 # https://developers.home-assistant.io/docs/config_entries_index/#setting-up-an-entry
 async def async_setup_entry(
     hass: HomeAssistant,


### PR DESCRIPTION
It seems like the subscriptions expire without the websocket having to reconnect.
As a userUpdate event is received at these times, this will be used to resubscribe.

I consider this a rather hacky way to do this, but it has proven to work for me for the last week without a connection loss or stale data on the sensor.