### PR TITLE
Add flap event sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 HomeAssistant integration for OnlyCat flaps.
 
+## Features
+1. Discover all flaps associated with one account
+2. Show flap connection status
+3. Show and allow to select active door policy (policies have to be created/modified via app)
+4. Show event activity (timestamp, rfids)
+
+## How to install
+1. Install HACS
+2. Add this respository to HACS via "Custom Repostiories"
+3. Install OnlyCat Integration
+
 ## Development
 
 1. Install pip requirements via ´pip install -r requirements.txt´

--- a/custom_components/onlycat/__init__.py
+++ b/custom_components/onlycat/__init__.py
@@ -52,7 +52,11 @@ async def async_setup_entry(
             await entry.runtime_data.client.send_message(
                 "getDevice", {"deviceId": device, "subscribe": True}
             )
+            await entry.runtime_data.client.send_message(
+                "getDeviceEvents", {"deviceId": device, "subscribe": True}
+            )
 
+    await refresh_subscriptions(None)
     entry.runtime_data.client.add_event_listener("connect", refresh_subscriptions)
     entry.runtime_data.client.add_event_listener("userUpdate", refresh_subscriptions)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/custom_components/onlycat/api.py
+++ b/custom_components/onlycat/api.py
@@ -85,7 +85,7 @@ class OnlyCatApiClient:
 
     async def send_message(self, event: str, data: any) -> Any | None:
         """Send a message to the API."""
-        _LOGGER.debug("Sending message to API: %s", data)
+        _LOGGER.debug("Sending %s message to API: %s", event, data)
         return await self._socket.call(event, data)
 
     async def on_any_event(self, event: str, *args: Any) -> None:

--- a/custom_components/onlycat/binary_sensor.py
+++ b/custom_components/onlycat/binary_sensor.py
@@ -2,35 +2,16 @@
 
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING
 
-from homeassistant.components.binary_sensor import (
-    BinarySensorDeviceClass,
-    BinarySensorEntity,
-    BinarySensorEntityDescription,
-)
-from homeassistant.const import EntityCategory
-from homeassistant.helpers.device_registry import DeviceInfo
-
-from .const import DOMAIN
-
-_LOGGER = logging.getLogger(__name__)
-
+from .binary_sensor_connectivity import OnlyCatConnectionSensor
+from .binary_sensor_event import OnlyCatEventSensor
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-    from .api import OnlyCatApiClient
     from .data import OnlyCatConfigEntry
-
-
-ENTITY_DESCRIPTION = BinarySensorEntityDescription(
-    key="OnlyCat",
-    name="OnlyCat Flap",
-    device_class=BinarySensorDeviceClass.CONNECTIVITY,
-)
 
 
 async def async_setup_entry(
@@ -40,58 +21,16 @@ async def async_setup_entry(
 ) -> None:
     """Set up the sensor platform."""
     async_add_entities(
-        OnlyCatConnectionSensor(
-            device=device,
-            entity_description=ENTITY_DESCRIPTION,
-            api_client=entry.runtime_data.client,
-        )
+        sensor
         for device in entry.data["devices"]
+        for sensor in (
+            OnlyCatEventSensor(
+                device=device,
+                api_client=entry.runtime_data.client,
+            ),
+            OnlyCatConnectionSensor(
+                device=device,
+                api_client=entry.runtime_data.client,
+            ),
+        )
     )
-
-
-class OnlyCatConnectionSensor(BinarySensorEntity):
-    """OnlyCat Sensor class."""
-
-    _attr_has_entity_name = True
-    _attr_should_poll = False
-    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
-    entity_category = EntityCategory.DIAGNOSTIC
-    _attr_translation_key = "onlycat_connection_sensor"
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device info to map to a device."""
-        return DeviceInfo(
-            identifiers={(DOMAIN, self.device["deviceId"])},
-            name=self.device["description"],
-            serial_number=self.device["deviceId"],
-        )
-
-    def __init__(
-        self,
-        device: dict,
-        entity_description: BinarySensorEntityDescription,
-        api_client: OnlyCatApiClient,
-    ) -> None:
-        """Initialize the sensor class."""
-        self.entity_description = entity_description
-        self._state = None
-        self._attr_raw_data = None
-        self.device = device
-        self._attr_name = "Connectivity"
-        self._attr_unique_id = (
-            device["deviceId"].replace("-", "_").lower() + "_connectivity"
-        )
-        self.entity_id = "binary_sensor." + self._attr_unique_id
-        api_client.add_event_listener("deviceUpdate", self.on_device_update)
-
-    async def on_device_update(self, data: dict) -> None:
-        """Handle device update event."""
-        _LOGGER.debug("Device update event received for binary sensor: %s", data)
-        self._attr_raw_data = str(data)
-        self.async_write_ha_state()
-
-    @property
-    def is_on(self) -> bool:
-        """Return if device is connected."""
-        return self.device["connectivity"]["connected"]

--- a/custom_components/onlycat/binary_sensor_connectivity.py
+++ b/custom_components/onlycat/binary_sensor_connectivity.py
@@ -1,0 +1,74 @@
+"""Sensor platform for OnlyCat."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.const import EntityCategory
+from homeassistant.helpers.device_registry import DeviceInfo
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from .api import OnlyCatApiClient
+
+ENTITY_DESCRIPTION = BinarySensorEntityDescription(
+    key="OnlyCat",
+    name="OnlyCat Flap",
+    device_class=BinarySensorDeviceClass.CONNECTIVITY,
+)
+
+
+class OnlyCatConnectionSensor(BinarySensorEntity):
+    """OnlyCat Sensor class."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+    entity_category = EntityCategory.DIAGNOSTIC
+    _attr_translation_key = "onlycat_connection_sensor"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info to map to a device."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self.device["deviceId"])},
+            name=self.device["description"],
+            serial_number=self.device["deviceId"],
+        )
+
+    def __init__(
+        self,
+        device: dict,
+        api_client: OnlyCatApiClient,
+    ) -> None:
+        """Initialize the sensor class."""
+        self.entity_description = ENTITY_DESCRIPTION
+        self._state = None
+        self._attr_raw_data = None
+        self.device = device
+        self._attr_name = "Connectivity"
+        self._attr_unique_id = (
+            device["deviceId"].replace("-", "_").lower() + "_connectivity"
+        )
+        self.entity_id = "binary_sensor." + self._attr_unique_id
+        api_client.add_event_listener("deviceUpdate", self.on_device_update)
+
+    async def on_device_update(self, data: dict) -> None:
+        """Handle device update event."""
+        _LOGGER.debug("Device update event received for binary sensor: %s", data)
+        self._attr_raw_data = str(data)
+        self.async_write_ha_state()
+
+    @property
+    def is_on(self) -> bool:
+        """Return if device is connected."""
+        return self.device["connectivity"]["connected"]

--- a/custom_components/onlycat/binary_sensor_event.py
+++ b/custom_components/onlycat/binary_sensor_event.py
@@ -18,11 +18,8 @@ from .const import DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from homeassistant.core import HomeAssistant
-    from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
     from .api import OnlyCatApiClient
-    from .data import OnlyCatConfigEntry
 
 
 ENTITY_DESCRIPTION = BinarySensorEntityDescription(

--- a/custom_components/onlycat/binary_sensor_event.py
+++ b/custom_components/onlycat/binary_sensor_event.py
@@ -1,0 +1,108 @@
+"""Sensor platform for OnlyCat."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.const import EntityCategory
+from homeassistant.helpers.device_registry import DeviceInfo
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+    from .api import OnlyCatApiClient
+    from .data import OnlyCatConfigEntry
+
+
+ENTITY_DESCRIPTION = BinarySensorEntityDescription(
+    key="OnlyCat",
+    name="OnlyCat Flap",
+    device_class=BinarySensorDeviceClass.MOTION,
+)
+
+
+class OnlyCatEventSensor(BinarySensorEntity):
+    """OnlyCat Sensor class."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+    _attr_device_class = BinarySensorDeviceClass.MOTION
+    entity_category = EntityCategory.DIAGNOSTIC
+    _attr_translation_key = "onlycat_event_sensor"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info to map to a device."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self.device["deviceId"])},
+            name=self.device["description"],
+            serial_number=self.device["deviceId"],
+        )
+
+    def __init__(
+        self,
+        device: dict,
+        api_client: OnlyCatApiClient,
+    ) -> None:
+        """Initialize the sensor class."""
+        self.entity_description = ENTITY_DESCRIPTION
+        self._state = False
+        self._attr_raw_data = None
+        self.device = device
+        self._attr_name = "Flap event"
+        self._attr_unique_id = device["deviceId"].replace("-", "_").lower() + "_event"
+        self._api_client = api_client
+        self.entity_id = "sensor." + self._attr_unique_id
+        api_client.add_event_listener("deviceEventUpdate", self.on_device_event_update)
+        api_client.add_event_listener("eventUpdate", self.on_event_update)
+
+    async def on_event_update(self, data: dict) -> None:
+        """Handle event update event."""
+        _LOGGER.debug("Event update event received for sensor: %s", data)
+        if (self._attr_extra_state_attributes["eventId"]) != data["eventId"]:
+            _LOGGER.debug("Event ID has changed, updating state.")
+            self._state = True
+        else:
+            if "frameCount" in data["body"] and data["body"]["frameCount"] > 0:
+                self._state = False
+            if "rfidCodes" in data["body"] and len(data["body"]["rfidCodes"]) > 0:
+                self._attr_extra_state_attributes["rfidCodes"] = data["body"][
+                    "rfidCodes"
+                ]
+        self.async_write_ha_state()
+
+    async def on_device_event_update(self, data: dict) -> None:
+        """Handle device event update event."""
+        _LOGGER.debug("Device event update event received for binary sensor: %s", data)
+        response = await self._api_client.send_message(
+            "getEvent",
+            {
+                "deviceId": data["deviceId"],
+                "eventId": data["eventId"],
+                "subscribe": True,
+            },
+        )
+        _LOGGER.debug("Response from getEvent: %s", response)
+        self._state = True
+        self._attr_extra_state_attributes = {
+            "eventId": response["eventId"],
+            "timestamp": response["timestamp"],
+            "eventTriggerSource": response["eventTriggerSource"],
+        }
+        self.async_write_ha_state()
+
+    @property
+    def is_on(self) -> bool:
+        """Return if device is connected."""
+        return self._state

--- a/custom_components/onlycat/binary_sensor_event.py
+++ b/custom_components/onlycat/binary_sensor_event.py
@@ -18,7 +18,6 @@ from .const import DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-
     from .api import OnlyCatApiClient
 
 


### PR DESCRIPTION
This PR adds a binary sensor (motion detection) that is listening to events of a flap.
The sensor is false, if the device is idle and true, if an event is currently happening.

The following information is available:
![Screenshot 2025-05-08 215625](https://github.com/user-attachments/assets/dc121c03-4334-4206-b279-71ecc5d1bcdd)
