### PR TITLE
Fix errors during eventUpdates to show RFID codes in event sensor.

### DIFF
--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -12,3 +12,7 @@ logger:
     custom_components.onlycat: debug
     socketio: debug
     aiohttp: debug
+
+debugpy:
+  start: true
+  wait: false

--- a/custom_components/onlycat/binary_sensor_contraband.py
+++ b/custom_components/onlycat/binary_sensor_contraband.py
@@ -70,7 +70,7 @@ class OnlyCatContrabandSensor(BinarySensorEntity):
         if data["deviceId"] != self.device.device_id:
             return
 
-        self._current_event.update_from(EventUpdate.from_api_response(data).body)
+        self._current_event.update_from(EventUpdate.from_api_response(data).event)
         self.determine_new_state(self._current_event)
         self.async_write_ha_state()
 

--- a/custom_components/onlycat/binary_sensor_event.py
+++ b/custom_components/onlycat/binary_sensor_event.py
@@ -13,7 +13,7 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.helpers.device_registry import DeviceInfo
 
 from .const import DOMAIN
-from .data.event import Event, EventUpdate
+from .data.event import EventUpdate
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -73,7 +73,11 @@ class OnlyCatEventSensor(BinarySensorEntity):
     def determine_new_state(self, event: EventUpdate) -> None:
         """Determine the new state of the sensor based on the event."""
         if (self._attr_extra_state_attributes.get("eventId")) != event.event_id:
-            _LOGGER.debug("Event ID has changed (%s -> %s), updating state.", self._attr_extra_state_attributes.get("eventId"), event.event_id)
+            _LOGGER.debug(
+                "Event ID has changed (%s -> %s), updating state.",
+                self._attr_extra_state_attributes.get("eventId"),
+                event.event_id,
+            )
             self._attr_is_on = True
             self._attr_extra_state_attributes = {
                 "eventId": event.event_id,

--- a/custom_components/onlycat/binary_sensor_lock.py
+++ b/custom_components/onlycat/binary_sensor_lock.py
@@ -67,7 +67,7 @@ class OnlyCatLockSensor(BinarySensorEntity):
         if data["deviceId"] != self.device.device_id:
             return
 
-        self._current_event.update_from(EventUpdate.from_api_response(data).body)
+        self._current_event.update_from(EventUpdate.from_api_response(data).event)
         self.determine_new_state(self._current_event)
         self.async_write_ha_state()
 

--- a/custom_components/onlycat/data/device.py
+++ b/custom_components/onlycat/data/device.py
@@ -49,7 +49,7 @@ class Device:
     device_id: str
     connectivity: DeviceConnectivity | None = None
     description: str | None = None
-    time_zone: tzinfo | None = None
+    time_zone: tzinfo | None = UTC
     device_transit_policy_id: int | None = None
     device_transit_policy: DeviceTransitPolicy | None = None
 

--- a/custom_components/onlycat/data/event.py
+++ b/custom_components/onlycat/data/event.py
@@ -104,7 +104,7 @@ class EventUpdate:
     device_id: str
     event_id: int
     type: Type
-    body: Event
+    event: Event
 
     @classmethod
     def from_api_response(cls, api_event: dict) -> EventUpdate | None:
@@ -114,10 +114,12 @@ class EventUpdate:
         event_type = (
             Type(api_event.get("type")) if api_event.get("type") else Type.UNKNOWN
         )
-        body = Event.from_api_response(api_event.get("body"))
+        event = Event.from_api_response(api_event.get("body"))
+        if event.event_id is None:
+            event.event_id = event_id
         return cls(
             device_id=device_id,
             event_id=event_id,
             type=event_type,
-            body=body,
+            event=event,
         )

--- a/custom_components/onlycat/data/event.py
+++ b/custom_components/onlycat/data/event.py
@@ -61,7 +61,7 @@ class Event:
     rfid_codes: list[str] | None = None
 
     @classmethod
-    def from_api_response(cls, api_event: dict, event_id: int | None = None) -> Event | None:
+    def from_api_response(cls, api_event: dict) -> Event | None:
         """Create an Event instance from API response data."""
         if not api_event:
             return None

--- a/custom_components/onlycat/data/event.py
+++ b/custom_components/onlycat/data/event.py
@@ -61,7 +61,7 @@ class Event:
     rfid_codes: list[str] | None = None
 
     @classmethod
-    def from_api_response(cls, api_event: dict) -> Event | None:
+    def from_api_response(cls, api_event: dict, event_id: int | None = None) -> Event | None:
         """Create an Event instance from API response data."""
         if not api_event:
             return None

--- a/custom_components/onlycat/data/event.py
+++ b/custom_components/onlycat/data/event.py
@@ -114,7 +114,7 @@ class EventUpdate:
         event_type = (
             Type(api_event.get("type")) if api_event.get("type") else Type.UNKNOWN
         )
-        body = api_event.get("body")
+        body = Event.from_api_response(api_event.get("body"))
         return cls(
             device_id=device_id,
             event_id=event_id,

--- a/custom_components/onlycat/data/event.py
+++ b/custom_components/onlycat/data/event.py
@@ -58,7 +58,7 @@ class Event:
     event_classification: EventClassification | None = EventClassification.UNKNOWN
     poster_frame_index: int | None = None
     access_token: str | None = None
-    rfid_codes: list[str] = []
+    rfid_codes: list[str] | None = None
 
     @classmethod
     def from_api_response(cls, api_event: dict) -> Event | None:
@@ -83,7 +83,7 @@ class Event:
             else None,
             poster_frame_index=api_event.get("posterFrameIndex"),
             access_token=api_event.get("accessToken"),
-            rfid_codes=api_event.get("rfidCodes"),
+            rfid_codes=api_event.get("rfidCodes", []),
         )
 
     def update_from(self, updated_event: Event) -> None:
@@ -111,11 +111,13 @@ class EventUpdate:
         """Create an EventUpdate instance from API response data."""
         device_id = api_event.get("deviceId", api_event.get("body").get("deviceId"))
         event_id = api_event.get("eventId", api_event.get("body").get("eventId"))
-        type = Type(api_event.get("type")) if api_event.get("type") else Type.UNKNOWN
+        event_type = (
+            Type(api_event.get("type")) if api_event.get("type") else Type.UNKNOWN
+        )
         body = api_event.get("body")
         return cls(
             device_id=device_id,
             event_id=event_id,
-            type=type,
+            type=event_type,
             body=body,
         )

--- a/custom_components/onlycat/data/event.py
+++ b/custom_components/onlycat/data/event.py
@@ -58,7 +58,7 @@ class Event:
     event_classification: EventClassification | None = EventClassification.UNKNOWN
     poster_frame_index: int | None = None
     access_token: str | None = None
-    rfid_codes: list[str] | None = None
+    rfid_codes: list[str] = []
 
     @classmethod
     def from_api_response(cls, api_event: dict) -> Event | None:
@@ -109,9 +109,13 @@ class EventUpdate:
     @classmethod
     def from_api_response(cls, api_event: dict) -> EventUpdate | None:
         """Create an EventUpdate instance from API response data."""
+        device_id = api_event.get("deviceId", api_event.get("body").get("deviceId"))
+        event_id = api_event.get("eventId", api_event.get("body").get("eventId"))
+        type = Type(api_event.get("type")) if api_event.get("type") else Type.UNKNOWN
+        body = api_event.get("body")
         return cls(
-            device_id=api_event["deviceId"],
-            event_id=api_event["eventId"],
-            type=Type(api_event["type"]) if api_event.get("type") else Type.UNKNOWN,
-            body=Event.from_api_response(api_event.get("body")),
+            device_id=device_id,
+            event_id=event_id,
+            type=type,
+            body=body,
         )

--- a/custom_components/onlycat/data/policy.py
+++ b/custom_components/onlycat/data/policy.py
@@ -175,7 +175,7 @@ class RuleCriteria:
             return False
 
         if self.rfid_codes and not any(
-                code in self.rfid_codes for code in event.rfid_codes
+            code in self.rfid_codes for code in event.rfid_codes
         ):
             return False
 

--- a/custom_components/onlycat/data/policy.py
+++ b/custom_components/onlycat/data/policy.py
@@ -174,7 +174,7 @@ class RuleCriteria:
         ):
             return False
 
-        if self.rfid_codes and not any(
+        if self.rfid_codes and event.rfid_codes and not any(
             code in self.rfid_codes for code in event.rfid_codes
         ):
             return False

--- a/custom_components/onlycat/data/policy.py
+++ b/custom_components/onlycat/data/policy.py
@@ -174,8 +174,10 @@ class RuleCriteria:
         ):
             return False
 
-        if self.rfid_codes and event.rfid_codes and not any(
-            code in self.rfid_codes for code in event.rfid_codes
+        if (
+            self.rfid_codes
+            and event.rfid_codes
+            and not any(code in self.rfid_codes for code in event.rfid_codes)
         ):
             return False
 

--- a/custom_components/onlycat/data/policy.py
+++ b/custom_components/onlycat/data/policy.py
@@ -174,10 +174,8 @@ class RuleCriteria:
         ):
             return False
 
-        if (
-            self.rfid_codes
-            and event.rfid_codes
-            and not any(code in self.rfid_codes for code in event.rfid_codes)
+        if self.rfid_codes and not any(
+                code in self.rfid_codes for code in event.rfid_codes
         ):
             return False
 

--- a/custom_components/onlycat/device_tracker.py
+++ b/custom_components/onlycat/device_tracker.py
@@ -114,7 +114,7 @@ class OnlyCatPetTracker(TrackerEntity):
         if data["deviceId"] != self.device.device_id:
             return
 
-        self._current_event.update_from(EventUpdate.from_api_response(data).body)
+        self._current_event.update_from(EventUpdate.from_api_response(data).event)
         self.determine_new_state(self._current_event)
         self.async_write_ha_state()
 


### PR DESCRIPTION
I had errors within my logs pointing towards a missing eventId while receiving an EventUpdate:
```
Error while handling event eventUpdate with args ({'deviceId': 'OC-000000', 'eventId': 3550, 'type': 'update', 'body': {'rfidCodes': ['0000']}},)
Traceback (most recent call last):
  File "/data/imladris/homeassistant/runtime/homeassistant_config/custom_components/onlycat/api.py", line 93, in handle_event
    await callback(*args)
  File "/data/imladris/homeassistant/runtime/homeassistant_config/custom_components/onlycat/binary_sensor_event.py", line 70, in on_event_update
    self.determine_new_state(EventUpdate.from_api_response(data).body)
    ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/imladris/homeassistant/runtime/homeassistant_config/custom_components/onlycat/binary_sensor_event.py", line 81, in determine_new_state
    "eventTriggerSource": event.event_trigger_source.name,
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'name'
```

Turns out not all eventUpdates include the eventId within the body, but within root.
I found out while wondering why the event sensor did not include RFID codes. 
I planned to use the RFID code for an automation scaring off foreign (and frankly quite aggressive) cats. 
