### PR TITLE
Fix fast events that only have RFIDs within getEvent

### DIFF
--- a/custom_components/onlycat/binary_sensor_contraband.py
+++ b/custom_components/onlycat/binary_sensor_contraband.py
@@ -64,6 +64,15 @@ class OnlyCatContrabandSensor(BinarySensorEntity):
 
         api_client.add_event_listener("deviceEventUpdate", self.on_event_update)
         api_client.add_event_listener("eventUpdate", self.on_event_update)
+        api_client.add_event_listener("getEvent", self.on_event)
+
+    async def on_event(self, data: dict) -> None:
+        """Handle bare event like returned from getEvent."""
+        if data["deviceId"] != self.device.device_id:
+            return
+        self._current_event.update_from(Event.from_api_response(data))
+        self.determine_new_state(self._current_event)
+        self.async_write_ha_state()
 
     async def on_event_update(self, data: dict) -> None:
         """Handle event update event."""

--- a/custom_components/onlycat/binary_sensor_event.py
+++ b/custom_components/onlycat/binary_sensor_event.py
@@ -61,6 +61,14 @@ class OnlyCatEventSensor(BinarySensorEntity):
 
         api_client.add_event_listener("deviceEventUpdate", self.on_event_update)
         api_client.add_event_listener("eventUpdate", self.on_event_update)
+        api_client.add_event_listener("getEvent", self.on_event)
+
+    async def on_event(self, data: dict) -> None:
+        """Handle bare event like returned from getEvent."""
+        if data["deviceId"] != self.device.device_id:
+            return
+        self.determine_new_state(Event.from_api_response(data))
+        self.async_write_ha_state()
 
     async def on_event_update(self, data: dict) -> None:
         """Handle event update event."""

--- a/custom_components/onlycat/binary_sensor_human.py
+++ b/custom_components/onlycat/binary_sensor_human.py
@@ -62,6 +62,16 @@ class OnlyCatHumanSensor(BinarySensorEntity):
 
         api_client.add_event_listener("deviceEventUpdate", self.on_event_update)
         api_client.add_event_listener("eventUpdate", self.on_event_update)
+        api_client.add_event_listener("getEvent", self.on_event)
+
+    async def on_event(self, data: dict) -> None:
+        """Handle bare event like returned from getEvent."""
+        if data["deviceId"] != self.device.device_id:
+            return
+        self._current_event.update_from(Event.from_api_response(data))
+        self.determine_new_state(self._current_event)
+        self.async_write_ha_state()
+
 
     async def on_event_update(self, data: dict) -> None:
         """Handle event update event."""

--- a/custom_components/onlycat/binary_sensor_human.py
+++ b/custom_components/onlycat/binary_sensor_human.py
@@ -72,7 +72,6 @@ class OnlyCatHumanSensor(BinarySensorEntity):
         self.determine_new_state(self._current_event)
         self.async_write_ha_state()
 
-
     async def on_event_update(self, data: dict) -> None:
         """Handle event update event."""
         if data["deviceId"] != self.device.device_id:

--- a/custom_components/onlycat/binary_sensor_lock.py
+++ b/custom_components/onlycat/binary_sensor_lock.py
@@ -61,6 +61,15 @@ class OnlyCatLockSensor(BinarySensorEntity):
         api_client.add_event_listener("deviceEventUpdate", self.on_event_update)
         api_client.add_event_listener("eventUpdate", self.on_event_update)
         api_client.add_event_listener("deviceUpdate", self.on_device_update)
+        api_client.add_event_listener("getEvent", self.on_event)
+
+    async def on_event(self, data: dict) -> None:
+        """Handle bare event like returned from getEvent."""
+        if data["deviceId"] != self.device.device_id:
+            return
+        self._current_event.update_from(Event.from_api_response(data))
+        self.determine_new_state(self._current_event)
+        self.async_write_ha_state()
 
     async def on_event_update(self, data: dict) -> None:
         """Handle event update event."""

--- a/custom_components/onlycat/data/event.py
+++ b/custom_components/onlycat/data/event.py
@@ -149,9 +149,6 @@ class EventUpdate:
         )
         event = Event.from_api_response(body)
 
-        # If body was empty, event might be None, but
-        # EventUpdate expects an Event object.
-        # Fallback to an empty Event if needed.
         if event is None:
             event = Event()
 

--- a/custom_components/onlycat/data/policy.py
+++ b/custom_components/onlycat/data/policy.py
@@ -399,7 +399,6 @@ class DeviceTransitPolicy:
                 event.event_id,
             )
             return PolicyResult.UNKNOWN
-
         if self.transit_policy.rules:
             for rule in self.transit_policy.rules:
                 if not rule.enabled:

--- a/custom_components/onlycat/device_tracker.py
+++ b/custom_components/onlycat/device_tracker.py
@@ -108,6 +108,15 @@ class OnlyCatPetTracker(TrackerEntity):
 
         api_client.add_event_listener("deviceEventUpdate", self.on_event_update)
         api_client.add_event_listener("eventUpdate", self.on_event_update)
+        api_client.add_event_listener("getEvent", self.on_event)
+
+    async def on_event(self, data: dict) -> None:
+        """Handle bare event like returned from getEvent."""
+        if data["deviceId"] != self.device.device_id:
+            return
+        self._current_event.update_from(Event.from_api_response(data))
+        self.determine_new_state(self._current_event)
+        self.async_write_ha_state()
 
     async def on_event_update(self, data: dict) -> None:
         """Handle event update event."""


### PR DESCRIPTION
Some events are too fast for EventUpdates to contain RFID information. Only the initial getEvent then contains RFID information but this info was previously discarded.

This may fix https://github.com/OnlyCatAI/onlycat-home-assistant/issues/81