### PR TITLE
Stream Validation & Bug Fixes

### DIFF
--- a/custom_components/onlycat/camera.py
+++ b/custom_components/onlycat/camera.py
@@ -7,6 +7,7 @@ import logging
 from http import HTTPStatus
 from typing import TYPE_CHECKING
 
+import aiohttp
 from homeassistant.components.camera import (
     Camera,
     CameraEntityDescription,
@@ -130,14 +131,14 @@ class OnlyCatLastVideo(Camera):
             f"{VIDEO_BASEURL}{event.device_id}/{event.event_id}?t={event.access_token}"
         )
 
-        # To avoid 5XX logs in HA, we briefly check if the URL is reachable
-        # and not returning a server error.
         session = async_get_clientsession(self.hass)
+
         try:
             async with session.head(url, timeout=2) as resp:
-                if resp.status >= 500:
+                if resp.status >= HTTPStatus.INTERNAL_SERVER_ERROR:
                     _LOGGER.debug(
-                        "OnlyCat video stream for event %s not ready or server error (status %s)",
+                        "OnlyCat video stream for event %s not ready or server error "
+                        "(status %s)",
                         event.event_id,
                         resp.status,
                     )
@@ -148,10 +149,8 @@ class OnlyCatLastVideo(Camera):
                         event.event_id,
                     )
                     return None
-        except Exception as err:  # pylint: disable=broad-except
+        except (aiohttp.ClientError, TimeoutError) as err:
             _LOGGER.debug("Error checking OnlyCat video availability: %s", err)
-            # In case of timeout or other network errors, we might want to skip for now
-            # to avoid HA's stream worker from logging its own errors.
             return None
 
         return url

--- a/custom_components/onlycat/camera.py
+++ b/custom_components/onlycat/camera.py
@@ -126,9 +126,35 @@ class OnlyCatLastVideo(Camera):
         if not self._current_event or not self._current_event.access_token:
             return None
         event = self._current_event
-        return (
+        url = (
             f"{VIDEO_BASEURL}{event.device_id}/{event.event_id}?t={event.access_token}"
         )
+
+        # To avoid 5XX logs in HA, we briefly check if the URL is reachable
+        # and not returning a server error.
+        session = async_get_clientsession(self.hass)
+        try:
+            async with session.head(url, timeout=2) as resp:
+                if resp.status >= 500:
+                    _LOGGER.debug(
+                        "OnlyCat video stream for event %s not ready or server error (status %s)",
+                        event.event_id,
+                        resp.status,
+                    )
+                    return None
+                if resp.status == HTTPStatus.NOT_FOUND:
+                    _LOGGER.debug(
+                        "OnlyCat video stream for event %s not found (404)",
+                        event.event_id,
+                    )
+                    return None
+        except Exception as err:  # pylint: disable=broad-except
+            _LOGGER.debug("Error checking OnlyCat video availability: %s", err)
+            # In case of timeout or other network errors, we might want to skip for now
+            # to avoid HA's stream worker from logging its own errors.
+            return None
+
+        return url
 
     async def on_event_update(self, event: Event) -> None:
         """Handle event update."""

--- a/custom_components/onlycat/data/event_store.py
+++ b/custom_components/onlycat/data/event_store.py
@@ -154,10 +154,10 @@ class EventStore:
         """Call all event summary listeners for a given device."""
         if device_id not in self._event_summary_update_listeners:
             return
-        event = self._current_events.get(device_id, None)
-        if event is not None and event.summary is not None and event.summary:
+        summary = self._current_summaries.get(device_id, None)
+        if summary is not None:
             for callback in self._event_summary_update_listeners[device_id]:
-                await callback(event.summary)
+                await callback(summary)
 
     async def run_pet_listeners(self, rfid_code: str) -> None:
         """Call all pet listeners for a given RFID code."""


### PR DESCRIPTION
### 1. Video Stream Validation (camera.py)
What was done: Implemented a pre-stream validation check using a lightweight HEAD request within the stream_source method before passing the video URL to Home Assistant.

Handling Errors: If the OnlyCat server returns a 5XX (Server Error) or 404 (Not Found) status code, the integration will intercept it and decline to provide the URL to Home Assistant.

Impact: This prevents the Home Assistant stream worker from spinning up unnecessarily when a video is either missing or the server is struggling. It effectively eliminates the massive influx of Server returned 5XX Server Error messages in the Home Assistant logs. In the UI, the video will gracefully display as "unavailable" or fallback to the last thumbnail instead of crashing the player.

### 2. Event Store Stability Fix (data/event_store.py)
What was done: Fixed a critical bug in the run_summary_listeners method.

Impact: Resolved an issue where the system was incorrectly trying to access a non-existent event.summary attribute, preventing potential AttributeError exceptions and sudden crashes during event summary processing.

Expected Outcome
Your Home Assistant logs will remain significantly cleaner and less noisy. The integration is now much more resilient against temporary OnlyCat cloud outages or processing delays, automatically loading the stream as soon as the server successfully serves the file.