### PR TITLE
Persist device tracker states

### DIFF
--- a/custom_components/onlycat/__init__.py
+++ b/custom_components/onlycat/__init__.py
@@ -191,8 +191,7 @@ async def async_reload_entry(
     entry: OnlyCatConfigEntry,
 ) -> None:
     """Reload config entry."""
-    await async_unload_entry(hass, entry)
-    await async_setup_entry(hass, entry)
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_migrate_entry(

--- a/custom_components/onlycat/device_tracker.py
+++ b/custom_components/onlycat/device_tracker.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from homeassistant.components.device_tracker import (
@@ -11,6 +12,7 @@ from homeassistant.components.device_tracker import (
     TrackerEntityDescription,
 )
 from homeassistant.const import STATE_HOME, STATE_NOT_HOME
+from homeassistant.helpers.restore_state import RestoreEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -43,7 +45,7 @@ async def async_setup_entry(
     )
 
 
-class OnlyCatPetTracker(TrackerEntity):
+class OnlyCatPetTracker(TrackerEntity, RestoreEntity):
     """OnlyCat Tracker class."""
 
     _attr_has_entity_name = True
@@ -67,7 +69,41 @@ class OnlyCatPetTracker(TrackerEntity):
         self._attr_unique_id = pet.rfid_code + "_tracker"
         self.entity_id = "device_tracker." + self._attr_unique_id
         self._attr_location_name = STATE_NOT_HOME
+        self._attr_last_seen = pet.last_seen
         self._event_store.add_pet_listener(pet.rfid_code, self.on_pet_update)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str] | None:
+        """Return device specific attributes, so last_seen survives restarts."""
+        if self._attr_last_seen is None:
+            return None
+        return {"last_seen": self._attr_last_seen.isoformat()}
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the previous location if it is more recent than the API state."""
+        await super().async_added_to_hass()
+        last_state = await self.async_get_last_state()
+        if last_state is None or last_state.state not in (
+            STATE_HOME,
+            STATE_NOT_HOME,
+        ):
+            return
+        restored_last_seen = None
+        last_seen_attr = last_state.attributes.get("last_seen")
+        if last_seen_attr is not None:
+            try:
+                restored_last_seen = datetime.fromisoformat(last_seen_attr)
+            except ValueError:
+                restored_last_seen = None
+        if self.pet.last_seen is not None and (
+            restored_last_seen is None or restored_last_seen <= self.pet.last_seen
+        ):
+            return
+        self.pet.location = last_state.state
+        self.pet.last_seen = restored_last_seen
+        self._attr_location_name = last_state.state
+        self._attr_last_seen = restored_last_seen
+        self.async_write_ha_state()
 
     async def on_pet_update(self, pet: Pet) -> None:
         """Handle updates to the pet data."""
@@ -84,5 +120,7 @@ class OnlyCatPetTracker(TrackerEntity):
             _LOGGER.debug("Manual update of location cannot be set to %s", location)
             return
         self.pet.location = location
+        self.pet.last_seen = datetime.now(UTC)
+        self._attr_last_seen = self.pet.last_seen
         self._attr_location_name = location
         self.async_write_ha_state()


### PR DESCRIPTION
Persist the device tracker states by:
1. Adding the device_trackers to HAs storage
2. On initialization take the most recent known state (indicated by last_seen timestamp) of these two:
  a. The recorded previous state
  b. The last event reported by the api
3. For this to be consistent, the manual update location method used by the services sets the current timestamp as last_seen.

Offers a solution for https://github.com/OnlyCatAI/onlycat-home-assistant/issues/158
