### PR TITLE
Update device_trakcers to use in_zones after 2026.6.0

### DIFF
--- a/custom_components/onlycat/device_tracker.py
+++ b/custom_components/onlycat/device_tracker.py
@@ -68,7 +68,7 @@ class OnlyCatPetTracker(TrackerEntity, RestoreEntity):
         }
         self._attr_unique_id = pet.rfid_code + "_tracker"
         self.entity_id = "device_tracker." + self._attr_unique_id
-        self._attr_location_name = STATE_NOT_HOME
+        self._attr_in_zones = ["zone.home"] if pet.location == STATE_HOME else []
         self._attr_last_seen = pet.last_seen
         self._event_store.add_pet_listener(pet.rfid_code, self.on_pet_update)
 
@@ -101,7 +101,7 @@ class OnlyCatPetTracker(TrackerEntity, RestoreEntity):
             return
         self.pet.location = last_state.state
         self.pet.last_seen = restored_last_seen
-        self._attr_location_name = last_state.state
+        self._attr_in_zones = ["zone.home"] if last_state.state == STATE_HOME else []
         self._attr_last_seen = restored_last_seen
         self.async_write_ha_state()
 
@@ -110,7 +110,7 @@ class OnlyCatPetTracker(TrackerEntity, RestoreEntity):
         if pet.rfid_code != self.pet.rfid_code:
             return
         self.pet = pet
-        self._attr_location_name = pet.location
+        self._attr_in_zones = ["zone.home"] if pet.location == STATE_HOME else []
         self._attr_last_seen = pet.last_seen
         self.async_write_ha_state()
 
@@ -122,5 +122,5 @@ class OnlyCatPetTracker(TrackerEntity, RestoreEntity):
         self.pet.location = location
         self.pet.last_seen = datetime.now(UTC)
         self._attr_last_seen = self.pet.last_seen
-        self._attr_location_name = location
+        self._attr_in_zones = ["zone.home"] if location == STATE_HOME else []
         self.async_write_ha_state()

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
     "name": "OnlyCat",
-    "homeassistant": "2026.2.3",
+    "homeassistant": "2026.6.0",
     "hacs": "2.0.1"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 colorlog==6.11.0
-homeassistant==2026.5.3
+homeassistant==2026.7.2
 pip>=26.1.2
 ruff==0.15.22
 pytest==9.1.1


### PR DESCRIPTION
As per https://developers.home-assistant.io/blog/2026/06/15/device-tracker-changes/
Fixes https://github.com/OnlyCatAI/onlycat-home-assistant/issues/161