### PR TITLE
Recover missed events and add safe history replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,3 +35,4 @@
 - Update test dependencies
 - Fix translations on setup screen
 ---
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,4 +35,3 @@
 - Update test dependencies
 - Fix translations on setup screen
 ---
-

--- a/README.md
+++ b/README.md
@@ -55,11 +55,16 @@ The flap event binary sensor records the summary subevents supplied by OnlyCat,
 including each RFID code, direction, and action. Access tokens are never exposed
 as entity attributes.
 
-The `onlycat.backfill_event_summaries` action can replay the recent history still
-available from the gateway into Home Assistant Recorder. It is manual-only,
-bounded by its `days` and `maximum_events` fields, and throttled to at most two
-summary requests per second. It does not add a polling loop or alter current pet
-locations, door policy, or flap state.
+The `onlycat.backfill_event_summaries` action can replay gateway history into
+Home Assistant Recorder. By default it is bounded by its `days` and
+`maximum_events` fields. Enabling `all_history` follows OnlyCat's
+`beforeGlobalId` cursor until the gateway has no older page. The action is
+manual-only and throttled to at most one gateway request per second. It does not
+add a polling loop or alter current pet locations, door policy, or flap state.
+
+Full-history backfills can take a long time. They are safe to repeat: gateway
+pages are deduplicated by event ID and Home Assistant's restored live event is
+kept separate from the historical replay path.
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ HomeAssistant integration for [OnlyCat](https://www.onlycat.com/) flaps.
   * 🐾 In case your pet chooses another exit, you can override the presence using the `set_pet_location` service
 * 🔎 Keep track of your device and build automations with it using binary sensors for:
    * 📶 Flap connection status
-   * 🕒 Flap events (including timestamps, RFID codes, trigger source, and event classification)
+   * 🕒 Flap events (including timestamps, exact summary RFID attribution,
+     direction, action, trigger source, and event classification)
    * 🐭 Contraband detection
    * 🔐 Lock state
    * 👤 Human detection
@@ -47,6 +48,18 @@ Common automation ideas enabled by this integration include:
 2. Search for "OnlyCat"
 3. Enter your configuration:
    * **API Key**: Enable Developer Mode in the OnlyCat app under Account, open API Keys, and create a key for Home Assistant.
+
+## Historical event summaries
+
+The flap event binary sensor records the summary subevents supplied by OnlyCat,
+including each RFID code, direction, and action. Access tokens are never exposed
+as entity attributes.
+
+The `onlycat.backfill_event_summaries` action can replay the recent history still
+available from the gateway into Home Assistant Recorder. It is manual-only,
+bounded by its `days` and `maximum_events` fields, and throttled to at most two
+summary requests per second. It does not add a polling loop or alter current pet
+locations, door policy, or flap state.
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,12 @@ Home Assistant Recorder. By default it is bounded by its `days` and
 `maximum_events` fields. Enabling `all_history` follows OnlyCat's
 `beforeGlobalId` cursor until the gateway has no older page. The action is
 manual-only and throttled to at most one gateway request per second. It does not
-add a polling loop or alter current pet locations, door policy, or flap state.
+alter current pet locations, door policy, or flap state.
+
+Live event delivery is reconciled automatically. After reconnecting, and every
+15 minutes as a safeguard against silent WebSocket gaps, the integration checks
+the gateway's latest event page and replays only event IDs it has not already
+processed. Summary requests are made only for those unseen events.
 
 Full-history backfills can take a long time. They are safe to repeat: gateway
 pages are deduplicated by event ID and Home Assistant's restored live event is

--- a/custom_components/onlycat/__init__.py
+++ b/custom_components/onlycat/__init__.py
@@ -7,17 +7,20 @@ https://github.com/OnlyCatAI/onlycat-home-assistant
 
 from __future__ import annotations
 
+import asyncio
 import logging
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
 from homeassistant.const import Platform
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.event import async_track_time_interval
 
 from .api import OnlyCatApiClient, OnlyCatApiClientCommunicationError
 from .coordinator import OnlyCatDataUpdateCoordinator
 from .data.__init__ import OnlyCatConfigEntry, OnlyCatData
 from .data.device import Device
+from .data.event import Event
 from .data.event_store import EventStore
 from .data.event_summary import SubEvent
 from .services import async_setup_services
@@ -35,10 +38,11 @@ PLATFORMS: list[Platform] = [
     Platform.CAMERA,
 ]
 _LOGGER = logging.getLogger(__name__)
+EVENT_RECONCILIATION_INTERVAL = timedelta(minutes=15)
 
 
 # https://developers.home-assistant.io/docs/config_entries_index/#setting-up-an-entry
-async def async_setup_entry(
+async def async_setup_entry(  # noqa: PLR0915
     hass: HomeAssistant,
     entry: OnlyCatConfigEntry,
 ) -> bool:
@@ -76,40 +80,76 @@ async def async_setup_entry(
         "eventSummaryUpdate", entry.runtime_data.event_store.on_event_summary_update
     )
 
-    async def refresh_subscriptions(args: dict | None) -> None:
-        _LOGGER.debug("Refreshing subscriptions, caused by event: %s", args)
-        for device in entry.runtime_data.devices:
-            await entry.runtime_data.client.send_message(
-                "getDevice", {"deviceId": device.device_id, "subscribe": True}
-            )
-            events = await entry.runtime_data.client.send_message(
-                "getDeviceEvents", {"deviceId": device.device_id, "subscribe": True}
-            )
-            if events:
-                events.sort(
-                    key=lambda e: datetime.fromisoformat(
-                        e.get(
-                            "timestamp",
-                            None,
-                        )
-                        or datetime.min.replace(tzinfo=UTC).isoformat()
-                    ),
-                    reverse=True,
-                )
-            if events and "eventId" in events[0]:
-                latest_event = events[0]
-                await entry.runtime_data.event_store.send_get_event_message(
-                    device.device_id, latest_event["eventId"], subscribe=False
-                )
-                if latest_event.get("accessToken"):
-                    await entry.runtime_data.event_store.send_get_event_summary(
-                        device.device_id,
-                        latest_event["eventId"],
-                        latest_event["accessToken"],
-                        subscribe=False,
-                    )
+    event_recovery_lock = asyncio.Lock()
 
-    await refresh_subscriptions(None)
+    async def process_event_history(
+        device_id: str, raw_events: list[dict], *, recover_unseen: bool
+    ) -> int:
+        """Seed or reconcile the first retained gateway event page."""
+        events = [
+            event
+            for raw_event in raw_events
+            if (event := Event.from_api_response(raw_event)) is not None
+            and event.device_id == device_id
+            and event.event_id is not None
+            and event.timestamp is not None
+        ]
+        if recover_unseen:
+            recovered = await entry.runtime_data.event_store.recover_unseen_events(
+                device_id, events
+            )
+            if recovered:
+                _LOGGER.info(
+                    "Recovered %s unseen OnlyCat events for %s", recovered, device_id
+                )
+            return recovered
+
+        entry.runtime_data.event_store.mark_events_seen(events)
+        return 0
+
+    async def hydrate_latest_event(device_id: str, events: list[dict]) -> None:
+        """Restore the newest event and pet location as live state."""
+        events.sort(
+            key=lambda event: datetime.fromisoformat(
+                event.get("timestamp") or datetime.min.replace(tzinfo=UTC).isoformat()
+            ),
+            reverse=True,
+        )
+        if not events or "eventId" not in events[0]:
+            return
+
+        latest_event = events[0]
+        await entry.runtime_data.event_store.send_get_event_message(
+            device_id, latest_event["eventId"], subscribe=False
+        )
+        if latest_event.get("accessToken"):
+            await entry.runtime_data.event_store.send_get_event_summary(
+                device_id,
+                latest_event["eventId"],
+                latest_event["accessToken"],
+                subscribe=False,
+            )
+
+    async def refresh_subscriptions(
+        args: dict | None, *, recover_unseen: bool = True
+    ) -> None:
+        _LOGGER.debug("Refreshing subscriptions, caused by event: %s", args)
+        async with event_recovery_lock:
+            for device in entry.runtime_data.devices:
+                await entry.runtime_data.client.send_message(
+                    "getDevice", {"deviceId": device.device_id, "subscribe": True}
+                )
+                events = await entry.runtime_data.client.send_message(
+                    "getDeviceEvents",
+                    {"deviceId": device.device_id, "subscribe": True},
+                )
+                events = events if isinstance(events, list) else []
+                await process_event_history(
+                    device.device_id, events, recover_unseen=recover_unseen
+                )
+                await hydrate_latest_event(device.device_id, events)
+
+    await refresh_subscriptions(None, recover_unseen=False)
 
     async def mark_disconnected(*_args: object) -> None:
         """Make entity availability reflect a lost OnlyCat cloud connection."""
@@ -124,6 +164,31 @@ async def async_setup_entry(
         await refresh_subscriptions(None)
         await entry.runtime_data.coordinator.async_refresh()
 
+    async def reconcile_event_history(_now: datetime) -> None:
+        """Recover silently dropped push events from the latest gateway page."""
+        try:
+            async with event_recovery_lock:
+                for device in entry.runtime_data.devices:
+                    events = await entry.runtime_data.client.send_message(
+                        "getDeviceEvents",
+                        {"deviceId": device.device_id, "subscribe": False},
+                        notify_listeners=False,
+                    )
+                    event_list = events if isinstance(events, list) else []
+                    recovered = await process_event_history(
+                        device.device_id,
+                        event_list,
+                        recover_unseen=True,
+                    )
+                    if recovered:
+                        await hydrate_latest_event(device.device_id, event_list)
+        except OnlyCatApiClientCommunicationError:
+            _LOGGER.warning(
+                "OnlyCat event reconciliation deferred while the gateway is offline"
+            )
+        except Exception:
+            _LOGGER.exception("Unexpected error reconciling OnlyCat event history")
+
     entry.runtime_data.client.add_event_listener("connect", handle_reconnect)
     entry.runtime_data.client.add_event_listener("disconnect", mark_disconnected)
     entry.runtime_data.client.add_event_listener("userUpdate", refresh_subscriptions)
@@ -133,6 +198,11 @@ async def async_setup_entry(
         await entry.runtime_data.event_store.run_event_listeners(device.device_id)
     for pet in entry.runtime_data.event_store.get_pets():
         await entry.runtime_data.event_store.run_pet_listeners(pet.rfid_code)
+    entry.async_on_unload(
+        async_track_time_interval(
+            hass, reconcile_event_history, EVENT_RECONCILIATION_INTERVAL
+        )
+    )
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
     return True
 

--- a/custom_components/onlycat/__init__.py
+++ b/custom_components/onlycat/__init__.py
@@ -97,9 +97,17 @@ async def async_setup_entry(
                     reverse=True,
                 )
             if events and "eventId" in events[0]:
+                latest_event = events[0]
                 await entry.runtime_data.event_store.send_get_event_message(
-                    device.device_id, events[0]["eventId"], subscribe=False
+                    device.device_id, latest_event["eventId"], subscribe=False
                 )
+                if latest_event.get("accessToken"):
+                    await entry.runtime_data.event_store.send_get_event_summary(
+                        device.device_id,
+                        latest_event["eventId"],
+                        latest_event["accessToken"],
+                        subscribe=False,
+                    )
 
     await refresh_subscriptions(None)
     entry.runtime_data.client.add_event_listener("connect", refresh_subscriptions)

--- a/custom_components/onlycat/__init__.py
+++ b/custom_components/onlycat/__init__.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING
 from homeassistant.const import Platform
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .api import OnlyCatApiClient
+from .api import OnlyCatApiClient, OnlyCatApiClientCommunicationError
 from .coordinator import OnlyCatDataUpdateCoordinator
 from .data.__init__ import OnlyCatConfigEntry, OnlyCatData
 from .data.device import Device
@@ -110,7 +110,22 @@ async def async_setup_entry(
                     )
 
     await refresh_subscriptions(None)
-    entry.runtime_data.client.add_event_listener("connect", refresh_subscriptions)
+
+    async def mark_disconnected(*_args: object) -> None:
+        """Make entity availability reflect a lost OnlyCat cloud connection."""
+        entry.runtime_data.coordinator.async_set_update_error(
+            OnlyCatApiClientCommunicationError(
+                "Disconnected from the OnlyCat cloud gateway"
+            )
+        )
+
+    async def handle_reconnect() -> None:
+        """Restore subscriptions and entity availability after reconnecting."""
+        await refresh_subscriptions(None)
+        await entry.runtime_data.coordinator.async_refresh()
+
+    entry.runtime_data.client.add_event_listener("connect", handle_reconnect)
+    entry.runtime_data.client.add_event_listener("disconnect", mark_disconnected)
     entry.runtime_data.client.add_event_listener("userUpdate", refresh_subscriptions)
     await async_setup_services(hass, entry)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/custom_components/onlycat/api.py
+++ b/custom_components/onlycat/api.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from collections import defaultdict
+from contextlib import suppress
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -16,6 +18,8 @@ import socketio
 _LOGGER = logging.getLogger(__name__)
 
 ONLYCAT_URL = "https://gateway.onlycat.com"
+RECONNECT_INITIAL_DELAY_SECONDS = 5.0
+RECONNECT_MAX_DELAY_SECONDS = 60.0
 
 
 class OnlyCatApiClientError(Exception):
@@ -49,39 +53,102 @@ class OnlyCatApiClient:
         self._data = data
         self._session = session
         self._listeners = defaultdict(list)
+        self._connect_lock = asyncio.Lock()
+        self._reconnect_task: asyncio.Task[None] | None = None
+        self._closing = False
         self._socket = socket or socketio.AsyncClient(
             http_session=self._session,
-            reconnection=True,
-            reconnection_attempts=0,
-            reconnection_delay=10,
-            reconnection_delay_max=10,
+            reconnection=False,
             ssl_verify=True,
         )
         self._socket.on("*", self.handle_event)
-        self.add_event_listener("connect", self.on_connected)
+        self._socket.on("connect", self.on_connected)
+        self._socket.on("disconnect", self.on_disconnected)
+
+    def _is_connected(self) -> bool:
+        """Return whether the default namespace is ready for calls."""
+        if not self._socket.connected:
+            return False
+
+        namespaces = getattr(self._socket, "namespaces", None)
+        return not isinstance(namespaces, dict) or "/" in namespaces
+
+    async def _connect_locked(self) -> None:
+        """Connect while the caller holds the connection lock."""
+        if self._is_connected():
+            return
+
+        _LOGGER.debug("Connecting to API")
+        await self._socket.connect(
+            ONLYCAT_URL,
+            transports=["websocket"],
+            namespaces="/",
+            headers={"platform": "home-assistant", "device": "onlycat-hass"},
+            auth={"token": self._token},
+        )
 
     async def connect(self) -> None:
-        """Connect to wesocket client."""
-        if self._socket.connected:
-            return
-        _LOGGER.debug("Connecting to API")
+        """Connect to websocket client."""
+        self._closing = False
 
         try:
-            await self._socket.connect(
-                ONLYCAT_URL,
-                transports=["websocket"],
-                namespaces="/",
-                headers={"platform": "home-assistant", "device": "onlycat-hass"},
-                auth={"token": self._token},
-            )
+            async with self._connect_lock:
+                await self._connect_locked()
         except Exception as exception:
             raise OnlyCatApiClientError from exception
 
     async def disconnect(self) -> None:
         """Disconnect websocket client."""
+        self._closing = True
+        reconnect_task = self._reconnect_task
+        self._reconnect_task = None
+        if reconnect_task and reconnect_task is not asyncio.current_task():
+            reconnect_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await reconnect_task
+
         _LOGGER.debug("Disconnecting from API")
-        await self._socket.disconnect()
+        if self._socket.connected:
+            await self._socket.disconnect()
         await self._socket.shutdown()
+
+    def _start_reconnect(self) -> None:
+        """Start one background reconnect loop if one is not already running."""
+        if self._closing or self._is_connected():
+            return
+        if self._reconnect_task and not self._reconnect_task.done():
+            return
+
+        self._reconnect_task = asyncio.create_task(
+            self._reconnect_loop(), name="onlycat-reconnect"
+        )
+
+    async def _reconnect_loop(self) -> None:
+        """Reconnect with bounded exponential backoff until connected or closed."""
+        delay = RECONNECT_INITIAL_DELAY_SECONDS
+        try:
+            while not self._closing and not self._is_connected():
+                await asyncio.sleep(delay)
+                try:
+                    async with self._connect_lock:
+                        await self._connect_locked()
+                except Exception:  # noqa: BLE001
+                    _LOGGER.warning(
+                        "Could not reconnect to OnlyCat; retrying in %.0f seconds",
+                        min(delay * 2, RECONNECT_MAX_DELAY_SECONDS),
+                        exc_info=True,
+                    )
+                    delay = min(delay * 2, RECONNECT_MAX_DELAY_SECONDS)
+        finally:
+            if self._reconnect_task is asyncio.current_task():
+                self._reconnect_task = None
+
+    async def _repair_namespace(self) -> None:
+        """Replace a transport that is connected without the default namespace."""
+        async with self._connect_lock:
+            if self._socket.connected:
+                await self._socket.disconnect()
+            await self._connect_locked()
 
     def add_event_listener(self, event: str, callback: Any) -> None:
         """Add an event listener."""
@@ -115,9 +182,31 @@ class OnlyCatApiClient:
             data,
             type(data),
         )
+
+        if not self._is_connected():
+            try:
+                await self.connect()
+            except OnlyCatApiClientError as exception:
+                self._start_reconnect()
+                raise OnlyCatApiClientCommunicationError from exception
+
         try:
             reply = await self._socket.call(event, data)
+        except socketio.exceptions.BadNamespaceError:
+            _LOGGER.warning(
+                "OnlyCat namespace disconnected during %s; reconnecting", event
+            )
+            try:
+                await self._repair_namespace()
+                reply = await self._socket.call(event, data)
+            except Exception as exception:
+                self._start_reconnect()
+                _LOGGER.exception(
+                    "Error retrying socket.call for event %s with data %s", event, data
+                )
+                raise OnlyCatApiClientCommunicationError from exception
         except Exception as exception:
+            self._start_reconnect()
             _LOGGER.exception(
                 "Error during socket.call for event %s with data %s", event, data
             )
@@ -145,3 +234,20 @@ class OnlyCatApiClient:
     async def on_connected(self) -> None:
         """Handle connected event."""
         _LOGGER.debug("(Re)connected to API")
+        for callback in self._listeners["connect"]:
+            try:
+                await callback()
+            except Exception:
+                _LOGGER.exception("Error while handling API reconnection")
+
+    async def on_disconnected(self, *args: Any) -> None:
+        """Handle a lost websocket connection."""
+        if self._closing:
+            return
+        _LOGGER.warning("Disconnected from OnlyCat API: %s", args or "unknown reason")
+        for callback in self._listeners["disconnect"]:
+            try:
+                await callback(*args)
+            except Exception:
+                _LOGGER.exception("Error while handling API disconnection")
+        self._start_reconnect()

--- a/custom_components/onlycat/api.py
+++ b/custom_components/onlycat/api.py
@@ -101,7 +101,13 @@ class OnlyCatApiClient:
                     "Error while handling event %s with args %s", event, args
                 )
 
-    async def send_message(self, event: str, data: any) -> Any | None:
+    async def send_message(
+        self,
+        event: str,
+        data: any,
+        *,
+        notify_listeners: bool = True,
+    ) -> Any | None:
         """Send a message to the API."""
         _LOGGER.debug(
             "Sending message to API - Event: %s, Data: %s, Data Type: %s",
@@ -119,16 +125,17 @@ class OnlyCatApiClient:
         _LOGGER.debug("Received reply for event %s: %s", event, reply)
         if reply is None:
             return None
-        for callback in self._listeners[event]:
-            try:
-                await callback(reply)
-            except Exception:
-                _LOGGER.exception(
-                    "Error while handling reply for event %s with data %s: %s",
-                    event,
-                    data,
-                    reply,
-                )
+        if notify_listeners:
+            for callback in self._listeners[event]:
+                try:
+                    await callback(reply)
+                except Exception:
+                    _LOGGER.exception(
+                        "Error while handling reply for event %s with data %s: %s",
+                        event,
+                        data,
+                        reply,
+                    )
         return reply
 
     async def wait(self) -> None:

--- a/custom_components/onlycat/binary_sensor_event.py
+++ b/custom_components/onlycat/binary_sensor_event.py
@@ -147,7 +147,7 @@ class OnlyCatEventSensor(BinarySensorEntity):
         self,
         event: Event,
         summary: EventSummary | None,
-        historical: bool,
+        historical: bool,  # noqa: FBT001
     ) -> None:
         """Record a historical event, then allow the live event to be restored."""
         self._write_event(event, summary, historical=historical)

--- a/custom_components/onlycat/binary_sensor_event.py
+++ b/custom_components/onlycat/binary_sensor_event.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from .data.device import Device
     from .data.event import Event
     from .data.event_store import EventStore
+    from .data.event_summary import EventSummary
 
 
 ENTITY_DESCRIPTION = BinarySensorEntityDescription(
@@ -63,30 +64,90 @@ class OnlyCatEventSensor(BinarySensorEntity):
         self._event_store.add_event_listener(
             self.device.device_id, self.on_event_update
         )
+        self._event_store.add_event_summary_listener(
+            self.device.device_id, self.on_event_summary_update
+        )
+        self._event_store.add_history_replay_listener(
+            self.device.device_id, self.on_history_replay
+        )
+
+    def _write_event(
+        self,
+        event: Event,
+        summary: EventSummary | None = None,
+        *,
+        historical: bool = False,
+    ) -> None:
+        """Write an event and its exact subevent attribution to Home Assistant."""
+        previous_event_id = self._attr_extra_state_attributes.get("eventId")
+        if previous_event_id != event.event_id:
+            _LOGGER.info(
+                "Event ID has changed (%s -> %s), updating state.",
+                previous_event_id,
+                event.event_id,
+            )
+
+        attributes = {
+            "eventId": event.event_id,
+            "timestamp": event.timestamp,
+        }
+        if event.event_trigger_source:
+            attributes["eventTriggerSource"] = event.event_trigger_source.name
+        if event.event_classification:
+            attributes["eventClassification"] = event.event_classification.name
+
+        rfid_codes = set(event.rfid_codes or [])
+        if summary is not None and summary.event_id == event.event_id:
+            attributes["eventSummary"] = [
+                {
+                    "startFrameIndex": subevent.start_frame_index,
+                    "endFrameIndex": subevent.end_frame_index,
+                    "rfidCode": subevent.rfid_code,
+                    "direction": subevent.direction,
+                    "action": subevent.action,
+                }
+                for subevent in summary.subevents
+            ]
+            if summary.processed_frame_count is not None:
+                attributes["processedFrameCount"] = summary.processed_frame_count
+            rfid_codes.update(
+                subevent.rfid_code
+                for subevent in summary.subevents
+                if subevent.rfid_code
+            )
+        if rfid_codes:
+            attributes["rfidCodes"] = sorted(rfid_codes)
+
+        self._attr_extra_state_attributes = attributes
+        if historical or event.frame_count is not None:
+            self._attr_is_on = False
+        elif previous_event_id != event.event_id:
+            self._attr_is_on = True
+        self.async_write_ha_state()
 
     async def on_event_update(self, event: Event) -> None:
         """Handle event update."""
         if not event:
             return
-        if (self._attr_extra_state_attributes.get("eventId")) != event.event_id:
-            _LOGGER.info(
-                "Event ID has changed (%s -> %s), updating state.",
-                self._attr_extra_state_attributes.get("eventId"),
-                event.event_id,
-            )
-            self._attr_is_on = True
-        self._attr_extra_state_attributes = {
-            "eventId": event.event_id,
-            "timestamp": event.timestamp,
-            "eventTriggerSource": event.event_trigger_source.name,
-        }
-        if event.event_classification:
-            self._attr_extra_state_attributes["eventClassification"] = (
-                event.event_classification.name
-            )
-        if event.rfid_codes:
-            self._attr_extra_state_attributes["rfidCodes"] = event.rfid_codes
-        if event.frame_count:
-            # Frame count is present, event is concluded
-            self._attr_is_on = False
-        self.async_write_ha_state()
+        summary = self._event_store.get_current_summary(self.device.device_id)
+        if summary is not None and summary.event_id != event.event_id:
+            summary = None
+        self._write_event(event, summary)
+
+    async def on_event_summary_update(self, summary: EventSummary) -> None:
+        """Merge exact RFID, direction, and action details into the current event."""
+        event_id = self._attr_extra_state_attributes.get("eventId")
+        if summary.event_id != event_id:
+            return
+        event = self._event_store.get_current_event(self.device.device_id)
+        if event is not None and event.event_id == summary.event_id:
+            self._write_event(event, summary)
+
+    async def on_history_replay(
+        self,
+        event: Event,
+        summary: EventSummary | None,
+        historical: bool,
+    ) -> None:
+        """Record a historical event, then allow the live event to be restored."""
+        self._write_event(event, summary, historical=historical)

--- a/custom_components/onlycat/data/event_store.py
+++ b/custom_components/onlycat/data/event_store.py
@@ -1,7 +1,10 @@
 """Manage global store of events per device."""
 
+import asyncio
 import logging
-from collections.abc import Callable
+from collections import defaultdict, deque
+from collections.abc import Callable, Iterable
+from datetime import UTC, datetime
 from typing import Any
 
 from homeassistant.const import STATE_UNKNOWN
@@ -13,6 +16,8 @@ from .event import Event, EventUpdate
 from .event_summary import EventSummary
 
 _LOGGER = logging.getLogger(__name__)
+MAX_SEEN_EVENT_IDS = 200
+RECOVERY_REQUEST_DELAY_SECONDS = 1.0
 
 
 class EventStore:
@@ -29,6 +34,81 @@ class EventStore:
         self._current_images: dict[str, bytes] = {}
         self._pets: dict[str, Pet] = {}
         self._api_client: OnlyCatApiClient = api_client
+        self._seen_event_ids: dict[str, deque[int]] = defaultdict(deque)
+        self._seen_event_id_sets: dict[str, set[int]] = defaultdict(set)
+
+    def mark_event_seen(self, device_id: str, event_id: int) -> None:
+        """Remember a successfully processed event using bounded memory."""
+        seen_ids = self._seen_event_id_sets[device_id]
+        if event_id in seen_ids:
+            return
+
+        ordered_ids = self._seen_event_ids[device_id]
+        if len(ordered_ids) >= MAX_SEEN_EVENT_IDS:
+            seen_ids.discard(ordered_ids.popleft())
+        ordered_ids.append(event_id)
+        seen_ids.add(event_id)
+
+    def mark_events_seen(self, events: Iterable[Event]) -> None:
+        """Establish an initial event-history baseline without replaying it."""
+        for event in events:
+            if event.device_id and event.event_id is not None:
+                self.mark_event_seen(event.device_id, event.event_id)
+
+    async def recover_unseen_events(
+        self, device_id: str, events: Iterable[Event]
+    ) -> int:
+        """Replay unseen gateway events in chronological order."""
+        unseen_events = sorted(
+            (
+                event
+                for event in events
+                if event.event_id is not None
+                and event.event_id not in self._seen_event_id_sets[device_id]
+            ),
+            key=lambda event: event.timestamp or datetime.min.replace(tzinfo=UTC),
+        )
+        recovered = 0
+
+        try:
+            for event in unseen_events:
+                summary = None
+                if event.access_token:
+                    raw_summary = await self._api_client.send_message(
+                        "getEventSummary",
+                        {
+                            "deviceId": device_id,
+                            "eventId": event.event_id,
+                            "accessToken": event.access_token,
+                            "subscribe": False,
+                        },
+                        notify_listeners=False,
+                    )
+                    summary = (
+                        EventSummary.from_api_response(raw_summary)
+                        if isinstance(raw_summary, dict)
+                        else None
+                    )
+                    await asyncio.sleep(RECOVERY_REQUEST_DELAY_SECONDS)
+
+                    if (
+                        summary is None
+                        or summary.device_id != device_id
+                        or summary.event_id != event.event_id
+                    ):
+                        _LOGGER.warning(
+                            "Could not reconcile OnlyCat event %s; will retry later",
+                            event.event_id,
+                        )
+                        continue
+
+                await self.run_history_replay_listeners(event, summary)
+                self.mark_event_seen(device_id, event.event_id)
+                recovered += 1
+        finally:
+            await self.restore_history_replay_listeners(device_id)
+
+        return recovered
 
     async def send_get_event_message(
         self,
@@ -89,6 +169,8 @@ class EventStore:
         event = Event.from_api_response(data) if isinstance(data, dict) else data
         if not event:
             return
+        if event.device_id and event.event_id is not None:
+            self.mark_event_seen(event.device_id, event.event_id)
         if event.device_id not in self._current_events:
             self._current_events[event.device_id] = event
         if self._current_events[event.device_id].event_id != event.event_id:
@@ -169,7 +251,7 @@ class EventStore:
         if event.device_id not in self._history_replay_listeners:
             return
         for callback in self._history_replay_listeners[event.device_id]:
-            await callback(event, summary, True)
+            await callback(event, summary, True)  # noqa: FBT003
 
     async def restore_history_replay_listeners(self, device_id: str) -> None:
         """Restore replay listeners to the current live event after a replay."""
@@ -180,7 +262,7 @@ class EventStore:
         if summary is not None and summary.event_id != event.event_id:
             summary = None
         for callback in self._history_replay_listeners[device_id]:
-            await callback(event, summary, False)
+            await callback(event, summary, False)  # noqa: FBT003
 
     async def run_pet_listeners(self, rfid_code: str) -> None:
         """Call all pet listeners for a given RFID code."""

--- a/custom_components/onlycat/data/event_store.py
+++ b/custom_components/onlycat/data/event_store.py
@@ -22,6 +22,7 @@ class EventStore:
         """Initialize EventStore with given api client."""
         self._event_update_listeners: dict[str, list[Callable]] = {}
         self._event_summary_update_listeners: dict[str, list[Callable]] = {}
+        self._history_replay_listeners: dict[str, list[Callable]] = {}
         self._pet_update_listeners: dict[str, list[Callable]] = {}
         self._current_events: dict[str, Event] = {}
         self._current_summaries: dict[str, EventSummary] = {}
@@ -159,6 +160,28 @@ class EventStore:
             for callback in self._event_summary_update_listeners[device_id]:
                 await callback(summary)
 
+    async def run_history_replay_listeners(
+        self,
+        event: Event,
+        summary: EventSummary | None,
+    ) -> None:
+        """Publish a historical event without changing live device or pet state."""
+        if event.device_id not in self._history_replay_listeners:
+            return
+        for callback in self._history_replay_listeners[event.device_id]:
+            await callback(event, summary, True)
+
+    async def restore_history_replay_listeners(self, device_id: str) -> None:
+        """Restore replay listeners to the current live event after a replay."""
+        event = self._current_events.get(device_id)
+        if event is None or device_id not in self._history_replay_listeners:
+            return
+        summary = self._current_summaries.get(device_id)
+        if summary is not None and summary.event_id != event.event_id:
+            summary = None
+        for callback in self._history_replay_listeners[device_id]:
+            await callback(event, summary, False)
+
     async def run_pet_listeners(self, rfid_code: str) -> None:
         """Call all pet listeners for a given RFID code."""
         if rfid_code not in self._pet_update_listeners:
@@ -179,6 +202,20 @@ class EventStore:
         if device_id not in self._event_summary_update_listeners:
             self._event_summary_update_listeners[device_id] = []
         self._event_summary_update_listeners[device_id].append(callback)
+
+    def add_history_replay_listener(self, device_id: str, callback: Callable) -> None:
+        """Add a listener used only to record historical events."""
+        if device_id not in self._history_replay_listeners:
+            self._history_replay_listeners[device_id] = []
+        self._history_replay_listeners[device_id].append(callback)
+
+    def get_current_summary(self, device_id: str) -> EventSummary | None:
+        """Return the current summary for a device, if available."""
+        return self._current_summaries.get(device_id)
+
+    def get_current_event(self, device_id: str) -> Event | None:
+        """Return the current event for a device, if available."""
+        return self._current_events.get(device_id)
 
     def add_pet_listener(self, rfid_code: str, callback: Callable) -> None:
         """Add function to a pets listener list."""

--- a/custom_components/onlycat/services.py
+++ b/custom_components/onlycat/services.py
@@ -1,20 +1,41 @@
 """Provides services for OnlyCat."""
 
+import asyncio
 import json
 import logging
+from datetime import UTC, datetime, timedelta
 
 import voluptuous as vol
 from homeassistant.const import STATE_HOME, STATE_NOT_HOME
-from homeassistant.core import HomeAssistant, ServiceCall, ServiceResponse
+from homeassistant.core import (
+    HomeAssistant,
+    ServiceCall,
+    ServiceResponse,
+    SupportsResponse,
+)
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import config_validation as cv
 
 from custom_components.onlycat.data import OnlyCatConfigEntry
 
 from .const import DOMAIN
+from .data.event import Event
+from .data.event_summary import EventSummary
 from .device_tracker import OnlyCatPetTracker
 
 _LOGGER = logging.getLogger(__name__)
+
+BACKFILL_DELAY_SECONDS = 0.5
+BACKFILL_SCHEMA = vol.Schema(
+    {
+        vol.Optional("days", default=7): vol.All(
+            vol.Coerce(int), vol.Range(min=1, max=31)
+        ),
+        vol.Optional("maximum_events", default=100): vol.All(
+            vol.Coerce(int), vol.Range(min=1, max=500)
+        ),
+    }
+)
 
 
 def _get_pet_tracker_entity(call: ServiceCall) -> OnlyCatPetTracker:
@@ -73,6 +94,20 @@ async def async_setup_services(hass: HomeAssistant, entry: OnlyCatConfigEntry) -
         ),
     )
 
+    async def backfill_event_summaries_handler(
+        call: ServiceCall,
+    ) -> ServiceResponse:
+        """Handle a bounded, manually requested event-summary backfill."""
+        return await async_handle_backfill_event_summaries(call, entry)
+
+    hass.services.async_register(
+        DOMAIN,
+        "backfill_event_summaries",
+        backfill_event_summaries_handler,
+        schema=BACKFILL_SCHEMA,
+        supports_response=SupportsResponse.OPTIONAL,
+    )
+
 
 async def async_handle_set_pet_presence(call: ServiceCall) -> ServiceResponse:
     """Handle the set presence service call."""
@@ -104,3 +139,90 @@ async def async_handle_update_device_policy(
     )
     await entry.runtime_data.coordinator.async_refresh()
     _LOGGER.info("Updated device policy %s: %s", policy_data, response)
+
+
+async def async_handle_backfill_event_summaries(
+    call: ServiceCall,
+    entry: OnlyCatConfigEntry,
+) -> ServiceResponse:
+    """Replay available gateway history into the event sensor and HA recorder."""
+    days = call.data["days"]
+    maximum_events = call.data["maximum_events"]
+    cutoff = datetime.now(UTC) - timedelta(days=days)
+    listed = 0
+    eligible = 0
+    replayed = 0
+    skipped = 0
+    failed = 0
+
+    for device in entry.runtime_data.devices:
+        try:
+            raw_events = await entry.runtime_data.client.send_message(
+                "getDeviceEvents",
+                {"deviceId": device.device_id, "subscribe": False},
+                notify_listeners=False,
+            )
+            raw_events = raw_events if isinstance(raw_events, list) else []
+            listed += len(raw_events)
+            events = [
+                event
+                for raw_event in raw_events
+                if (event := Event.from_api_response(raw_event)) is not None
+                and event.device_id == device.device_id
+                and event.timestamp is not None
+                and event.timestamp >= cutoff
+                and event.access_token
+            ]
+            events.sort(key=lambda event: event.timestamp)
+            events = events[-maximum_events:]
+            eligible += len(events)
+
+            for event in events:
+                try:
+                    raw_summary = await entry.runtime_data.client.send_message(
+                        "getEventSummary",
+                        {
+                            "deviceId": device.device_id,
+                            "eventId": event.event_id,
+                            "accessToken": event.access_token,
+                            "subscribe": False,
+                        },
+                        notify_listeners=False,
+                    )
+                    summary = (
+                        EventSummary.from_api_response(raw_summary)
+                        if isinstance(raw_summary, dict)
+                        else None
+                    )
+                    if (
+                        summary is None
+                        or summary.device_id != device.device_id
+                        or summary.event_id != event.event_id
+                    ):
+                        skipped += 1
+                        continue
+                    await entry.runtime_data.event_store.run_history_replay_listeners(
+                        event, summary
+                    )
+                    replayed += 1
+                except Exception:  # noqa: BLE001
+                    failed += 1
+                    _LOGGER.exception(
+                        "Could not backfill OnlyCat event %s", event.event_id
+                    )
+                finally:
+                    await asyncio.sleep(BACKFILL_DELAY_SECONDS)
+        finally:
+            await entry.runtime_data.event_store.restore_history_replay_listeners(
+                device.device_id
+            )
+
+    result = {
+        "listed": listed,
+        "eligible": eligible,
+        "replayed": replayed,
+        "skipped": skipped,
+        "failed": failed,
+    }
+    _LOGGER.info("OnlyCat event-summary backfill completed: %s", result)
+    return result

--- a/custom_components/onlycat/services.py
+++ b/custom_components/onlycat/services.py
@@ -186,9 +186,7 @@ async def _get_device_event_history(
             break
 
         global_ids = [
-            event.global_id
-            for event in page_events
-            if isinstance(event.global_id, int)
+            event.global_id for event in page_events if isinstance(event.global_id, int)
         ]
         if not global_ids:
             _LOGGER.warning(
@@ -202,8 +200,7 @@ async def _get_device_event_history(
             before_global_id is not None and next_cursor >= before_global_id
         ):
             _LOGGER.warning(
-                "OnlyCat history cursor did not move backwards for %s; "
-                "stopping at %s",
+                "OnlyCat history cursor did not move backwards for %s; stopping at %s",
                 device_id,
                 next_cursor,
             )
@@ -276,9 +273,7 @@ async def async_handle_backfill_event_summaries(
             listed += device_listed
             unique_events += len(events)
             events = [
-                event
-                for event in events
-                if cutoff is None or event.timestamp >= cutoff
+                event for event in events if cutoff is None or event.timestamp >= cutoff
             ]
             events.sort(key=lambda event: event.timestamp)
             if not all_history:
@@ -292,7 +287,7 @@ async def async_handle_backfill_event_summaries(
                         summary = await _get_historical_event_summary(
                             entry, device.device_id, event
                         )
-                    except Exception:  # noqa: BLE001
+                    except Exception:
                         failed += 1
                         _LOGGER.exception(
                             "Could not fetch the summary for OnlyCat event %s; "

--- a/custom_components/onlycat/services.py
+++ b/custom_components/onlycat/services.py
@@ -25,9 +25,12 @@ from .device_tracker import OnlyCatPetTracker
 
 _LOGGER = logging.getLogger(__name__)
 
-BACKFILL_DELAY_SECONDS = 0.5
+BACKFILL_DELAY_SECONDS = 1.0
+BACKFILL_PAGE_DELAY_SECONDS = 1.0
+BACKFILL_PROGRESS_INTERVAL = 25
 BACKFILL_SCHEMA = vol.Schema(
     {
+        vol.Optional("all_history", default=False): cv.boolean,
         vol.Optional("days", default=7): vol.All(
             vol.Coerce(int), vol.Range(min=1, max=31)
         ),
@@ -141,86 +144,191 @@ async def async_handle_update_device_policy(
     _LOGGER.info("Updated device policy %s: %s", policy_data, response)
 
 
+async def _get_device_event_history(
+    entry: OnlyCatConfigEntry,
+    device_id: str,
+    *,
+    all_history: bool,
+) -> tuple[list[Event], int, int]:
+    """Fetch one recent page or paginate through all retained device events."""
+    events_by_id: dict[int, Event] = {}
+    before_global_id: int | None = None
+    seen_cursors: set[int] = set()
+    pages = 0
+    listed = 0
+
+    while True:
+        request = {"deviceId": device_id, "subscribe": False}
+        if before_global_id is not None:
+            request["beforeGlobalId"] = before_global_id
+
+        raw_events = await entry.runtime_data.client.send_message(
+            "getDeviceEvents",
+            request,
+            notify_listeners=False,
+        )
+        pages += 1
+        raw_events = raw_events if isinstance(raw_events, list) else []
+        listed += len(raw_events)
+
+        page_events = [
+            event
+            for raw_event in raw_events
+            if (event := Event.from_api_response(raw_event)) is not None
+            and event.device_id == device_id
+            and event.event_id is not None
+            and event.timestamp is not None
+        ]
+        for event in page_events:
+            events_by_id[event.event_id] = event
+
+        if not all_history or not raw_events:
+            break
+
+        global_ids = [
+            event.global_id
+            for event in page_events
+            if isinstance(event.global_id, int)
+        ]
+        if not global_ids:
+            _LOGGER.warning(
+                "OnlyCat history page for %s had no global IDs; stopping pagination",
+                device_id,
+            )
+            break
+
+        next_cursor = min(global_ids)
+        if next_cursor in seen_cursors or (
+            before_global_id is not None and next_cursor >= before_global_id
+        ):
+            _LOGGER.warning(
+                "OnlyCat history cursor did not move backwards for %s; "
+                "stopping at %s",
+                device_id,
+                next_cursor,
+            )
+            break
+
+        seen_cursors.add(next_cursor)
+        before_global_id = next_cursor
+        await asyncio.sleep(BACKFILL_PAGE_DELAY_SECONDS)
+
+    return list(events_by_id.values()), pages, listed
+
+
+async def _get_historical_event_summary(
+    entry: OnlyCatConfigEntry,
+    device_id: str,
+    event: Event,
+) -> EventSummary | None:
+    """Fetch and validate one historical event summary."""
+    if not event.access_token:
+        return None
+
+    raw_summary = await entry.runtime_data.client.send_message(
+        "getEventSummary",
+        {
+            "deviceId": device_id,
+            "eventId": event.event_id,
+            "accessToken": event.access_token,
+            "subscribe": False,
+        },
+        notify_listeners=False,
+    )
+    summary = (
+        EventSummary.from_api_response(raw_summary)
+        if isinstance(raw_summary, dict)
+        else None
+    )
+    if (
+        summary is None
+        or summary.device_id != device_id
+        or summary.event_id != event.event_id
+    ):
+        return None
+    return summary
+
+
 async def async_handle_backfill_event_summaries(
     call: ServiceCall,
     entry: OnlyCatConfigEntry,
 ) -> ServiceResponse:
     """Replay available gateway history into the event sensor and HA recorder."""
-    days = call.data["days"]
-    maximum_events = call.data["maximum_events"]
-    cutoff = datetime.now(UTC) - timedelta(days=days)
+    all_history = call.data.get("all_history", False)
+    days = call.data.get("days", 7)
+    maximum_events = call.data.get("maximum_events", 100)
+    cutoff = None if all_history else datetime.now(UTC) - timedelta(days=days)
+    pages = 0
     listed = 0
+    unique_events = 0
     eligible = 0
     replayed = 0
     skipped = 0
     failed = 0
+    summaries = 0
 
     for device in entry.runtime_data.devices:
         try:
-            raw_events = await entry.runtime_data.client.send_message(
-                "getDeviceEvents",
-                {"deviceId": device.device_id, "subscribe": False},
-                notify_listeners=False,
+            events, device_pages, device_listed = await _get_device_event_history(
+                entry, device.device_id, all_history=all_history
             )
-            raw_events = raw_events if isinstance(raw_events, list) else []
-            listed += len(raw_events)
+            pages += device_pages
+            listed += device_listed
+            unique_events += len(events)
             events = [
                 event
-                for raw_event in raw_events
-                if (event := Event.from_api_response(raw_event)) is not None
-                and event.device_id == device.device_id
-                and event.timestamp is not None
-                and event.timestamp >= cutoff
-                and event.access_token
+                for event in events
+                if cutoff is None or event.timestamp >= cutoff
             ]
             events.sort(key=lambda event: event.timestamp)
-            events = events[-maximum_events:]
+            if not all_history:
+                events = events[-maximum_events:]
             eligible += len(events)
 
-            for event in events:
-                try:
-                    raw_summary = await entry.runtime_data.client.send_message(
-                        "getEventSummary",
-                        {
-                            "deviceId": device.device_id,
-                            "eventId": event.event_id,
-                            "accessToken": event.access_token,
-                            "subscribe": False,
-                        },
-                        notify_listeners=False,
-                    )
-                    summary = (
-                        EventSummary.from_api_response(raw_summary)
-                        if isinstance(raw_summary, dict)
-                        else None
-                    )
-                    if (
-                        summary is None
-                        or summary.device_id != device.device_id
-                        or summary.event_id != event.event_id
-                    ):
-                        skipped += 1
-                        continue
-                    await entry.runtime_data.event_store.run_history_replay_listeners(
-                        event, summary
-                    )
-                    replayed += 1
-                except Exception:  # noqa: BLE001
-                    failed += 1
-                    _LOGGER.exception(
-                        "Could not backfill OnlyCat event %s", event.event_id
-                    )
-                finally:
+            for index, event in enumerate(events, start=1):
+                summary = None
+                if event.access_token:
+                    try:
+                        summary = await _get_historical_event_summary(
+                            entry, device.device_id, event
+                        )
+                    except Exception:  # noqa: BLE001
+                        failed += 1
+                        _LOGGER.exception(
+                            "Could not fetch the summary for OnlyCat event %s; "
+                            "replaying its base event",
+                            event.event_id,
+                        )
                     await asyncio.sleep(BACKFILL_DELAY_SECONDS)
+
+                if summary is None:
+                    skipped += 1
+                else:
+                    summaries += 1
+                await entry.runtime_data.event_store.run_history_replay_listeners(
+                    event, summary
+                )
+                replayed += 1
+
+                if index % BACKFILL_PROGRESS_INTERVAL == 0:
+                    _LOGGER.info(
+                        "OnlyCat history backfill progress for %s: %s/%s events",
+                        device.device_id,
+                        index,
+                        len(events),
+                    )
         finally:
             await entry.runtime_data.event_store.restore_history_replay_listeners(
                 device.device_id
             )
 
     result = {
+        "pages": pages,
         "listed": listed,
+        "unique_events": unique_events,
         "eligible": eligible,
         "replayed": replayed,
+        "summaries": summaries,
         "skipped": skipped,
         "failed": failed,
     }

--- a/custom_components/onlycat/services.yaml
+++ b/custom_components/onlycat/services.yaml
@@ -31,13 +31,22 @@ toggle_pet_location:
 backfill_event_summaries:
   name: Backfill event summaries
   description: >-
-    Replays the recent event history still available from the OnlyCat gateway so
-    Home Assistant Recorder can retain exact RFID, direction, and action details.
-    This is a manual, throttled one-shot operation and does not add polling.
+    Replays event history from the OnlyCat gateway so Home Assistant Recorder can
+    retain exact RFID, direction, and action details. This is a manual, throttled
+    one-shot operation and does not add polling.
   fields:
+    all_history:
+      name: All history
+      description: >-
+        Page backwards through the complete history retained by OnlyCat. When
+        enabled, Days and Maximum events are ignored. This can take a long time.
+      default: false
+      required: true
+      selector:
+        boolean:
     days:
       name: Days
-      description: Ignore gateway events older than this many days.
+      description: Ignore gateway events older than this many days unless All history is enabled.
       default: 7
       required: true
       selector:
@@ -47,7 +56,7 @@ backfill_event_summaries:
           mode: box
     maximum_events:
       name: Maximum events
-      description: Maximum number of recent events to replay per cat flap.
+      description: Maximum recent events to replay per cat flap unless All history is enabled.
       default: 100
       required: true
       selector:

--- a/custom_components/onlycat/services.yaml
+++ b/custom_components/onlycat/services.yaml
@@ -27,3 +27,31 @@ toggle_pet_location:
       selector:
         entity:
           domain: device_tracker
+
+backfill_event_summaries:
+  name: Backfill event summaries
+  description: >-
+    Replays the recent event history still available from the OnlyCat gateway so
+    Home Assistant Recorder can retain exact RFID, direction, and action details.
+    This is a manual, throttled one-shot operation and does not add polling.
+  fields:
+    days:
+      name: Days
+      description: Ignore gateway events older than this many days.
+      default: 7
+      required: true
+      selector:
+        number:
+          min: 1
+          max: 31
+          mode: box
+    maximum_events:
+      name: Maximum events
+      description: Maximum number of recent events to replay per cat flap.
+      default: 100
+      required: true
+      selector:
+        number:
+          min: 1
+          max: 500
+          mode: box

--- a/custom_components/onlycat/tests/test_api.py
+++ b/custom_components/onlycat/tests/test_api.py
@@ -1,18 +1,32 @@
 """Tests for the OnlyCat API client."""
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+import socketio
 
+from custom_components.onlycat import api
 from custom_components.onlycat.api import OnlyCatApiClient
+
+
+def create_socket(*, connected: bool = True) -> MagicMock:
+    """Create a Socket.IO client mock with realistic connection state."""
+    socket = MagicMock()
+    socket.connected = connected
+    socket.namespaces = {"/": "sid"} if connected else {}
+    socket.call = AsyncMock(return_value={"value": 1})
+    socket.connect = AsyncMock()
+    socket.disconnect = AsyncMock()
+    socket.shutdown = AsyncMock()
+    return socket
 
 
 @pytest.mark.asyncio
 async def test_send_message_can_skip_reply_listeners() -> None:
     """A backfill query can consume a reply without mutating live state."""
-    socket = MagicMock()
-    socket.call = AsyncMock(return_value={"value": 1})
-    client = OnlyCatApiClient("token", MagicMock(), socket=socket)  # noqa: S106
+    socket = create_socket()
+    client = OnlyCatApiClient("token", MagicMock(), socket=socket)
     listener = AsyncMock()
     client.add_event_listener("getEventSummary", listener)
 
@@ -22,3 +36,99 @@ async def test_send_message_can_skip_reply_listeners() -> None:
 
     assert reply == {"value": 1}
     listener.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_send_message_connects_when_namespace_is_missing() -> None:
+    """Calls reconnect before use when the default namespace is absent."""
+    socket = create_socket(connected=False)
+
+    async def connect(*_args: object, **_kwargs: object) -> None:
+        socket.connected = True
+        socket.namespaces = {"/": "sid"}
+
+    socket.connect.side_effect = connect
+    client = OnlyCatApiClient("token", MagicMock(), socket=socket)
+
+    reply = await client.send_message("getDevices", {"subscribe": True})
+
+    assert reply == {"value": 1}
+    socket.connect.assert_awaited_once()
+    socket.call.assert_awaited_once_with("getDevices", {"subscribe": True})
+
+
+@pytest.mark.asyncio
+async def test_send_message_repairs_bad_namespace_and_retries_once() -> None:
+    """A proven unsent call is retried after replacing its broken namespace."""
+    socket = create_socket()
+    socket.call.side_effect = [
+        socketio.exceptions.BadNamespaceError("/ is not connected"),
+        {"value": 2},
+    ]
+
+    async def disconnect() -> None:
+        socket.connected = False
+        socket.namespaces = {}
+
+    async def connect(*_args: object, **_kwargs: object) -> None:
+        socket.connected = True
+        socket.namespaces = {"/": "new-sid"}
+
+    socket.disconnect.side_effect = disconnect
+    socket.connect.side_effect = connect
+    client = OnlyCatApiClient("token", MagicMock(), socket=socket)
+
+    reply = await client.send_message("getDevices", {"subscribe": True})
+
+    assert reply == {"value": 2}
+    socket.disconnect.assert_awaited_once()
+    socket.connect.assert_awaited_once()
+    expected_call_count = 2
+    assert socket.call.await_count == expected_call_count
+
+
+@pytest.mark.asyncio
+async def test_disconnect_event_starts_single_reconnect_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Repeated disconnect notifications share one reconnect attempt."""
+    monkeypatch.setattr(api, "RECONNECT_INITIAL_DELAY_SECONDS", 0)
+    socket = create_socket(connected=False)
+    connect_started = asyncio.Event()
+    allow_connect = asyncio.Event()
+
+    async def connect(*_args: object, **_kwargs: object) -> None:
+        connect_started.set()
+        await allow_connect.wait()
+        socket.connected = True
+        socket.namespaces = {"/": "new-sid"}
+
+    socket.connect.side_effect = connect
+    client = OnlyCatApiClient("token", MagicMock(), socket=socket)
+    disconnected = AsyncMock()
+    client.add_event_listener("disconnect", disconnected)
+
+    await client.on_disconnected("transport error")
+    await client.on_disconnected("transport error")
+    await asyncio.wait_for(connect_started.wait(), timeout=1)
+    allow_connect.set()
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    socket.connect.assert_awaited_once()
+    expected_disconnect_notifications = 2
+    assert disconnected.await_count == expected_disconnect_notifications
+    await client.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_connect_event_refreshes_registered_subscriptions() -> None:
+    """Reconnect listeners run after the namespace is restored."""
+    socket = create_socket()
+    client = OnlyCatApiClient("token", MagicMock(), socket=socket)
+    refresh_subscriptions = AsyncMock()
+    client.add_event_listener("connect", refresh_subscriptions)
+
+    await client.on_connected()
+
+    refresh_subscriptions.assert_awaited_once_with()

--- a/custom_components/onlycat/tests/test_api.py
+++ b/custom_components/onlycat/tests/test_api.py
@@ -1,0 +1,24 @@
+"""Tests for the OnlyCat API client."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.onlycat.api import OnlyCatApiClient
+
+
+@pytest.mark.asyncio
+async def test_send_message_can_skip_reply_listeners() -> None:
+    """A backfill query can consume a reply without mutating live state."""
+    socket = MagicMock()
+    socket.call = AsyncMock(return_value={"value": 1})
+    client = OnlyCatApiClient("token", MagicMock(), socket=socket)  # noqa: S106
+    listener = AsyncMock()
+    client.add_event_listener("getEventSummary", listener)
+
+    reply = await client.send_message(
+        "getEventSummary", {"eventId": 1}, notify_listeners=False
+    )
+
+    assert reply == {"value": 1}
+    listener.assert_not_awaited()

--- a/custom_components/onlycat/tests/test_binary_sensor_event.py
+++ b/custom_components/onlycat/tests/test_binary_sensor_event.py
@@ -30,7 +30,7 @@ async def test_event_summary_adds_exact_subevent_attributes() -> None:
         frame_count=12,
         event_trigger_source=EventTriggerSource.OUTDOOR_MOTION,
         event_classification=EventClassification.CONTRABAND,
-        access_token="must-not-be-published",
+        access_token="must-not-be-published",  # noqa: S106
         rfid_codes=[],
     )
     subevent = SubEvent.from_api_response(
@@ -45,7 +45,7 @@ async def test_event_summary_adds_exact_subevent_attributes() -> None:
     assert subevent is not None
     summary = EventSummary(device_id=device_id, event_id=1179, subevents=[subevent])
 
-    await sensor.on_history_replay(event, summary, True)
+    await sensor.on_history_replay(event, summary, True)  # noqa: FBT003
 
     assert sensor.extra_state_attributes == {
         "eventId": 1179,

--- a/custom_components/onlycat/tests/test_binary_sensor_event.py
+++ b/custom_components/onlycat/tests/test_binary_sensor_event.py
@@ -1,0 +1,67 @@
+"""Tests for the OnlyCat event sensor."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.onlycat.binary_sensor_event import OnlyCatEventSensor
+from custom_components.onlycat.data.event import (
+    Event,
+    EventClassification,
+    EventTriggerSource,
+)
+from custom_components.onlycat.data.event_store import EventStore
+from custom_components.onlycat.data.event_summary import EventSummary, SubEvent
+
+
+@pytest.mark.asyncio
+async def test_event_summary_adds_exact_subevent_attributes() -> None:
+    """Summary RFID, action, and direction are published without access tokens."""
+    device_id = "OC-00000000001"
+    store = EventStore(MagicMock())
+    sensor = OnlyCatEventSensor(
+        SimpleNamespace(device_id=device_id, description="Back Door"), store
+    )
+    sensor.async_write_ha_state = MagicMock()
+    event = Event(
+        device_id=device_id,
+        event_id=1179,
+        frame_count=12,
+        event_trigger_source=EventTriggerSource.OUTDOOR_MOTION,
+        event_classification=EventClassification.CONTRABAND,
+        access_token="must-not-be-published",
+        rfid_codes=[],
+    )
+    subevent = SubEvent.from_api_response(
+        {
+            "startFrameIndex": 1,
+            "endFrameIndex": 11,
+            "rfidCode": "958000000000001",
+            "direction": "INWARD",
+            "action": "LOCKED",
+        }
+    )
+    assert subevent is not None
+    summary = EventSummary(device_id=device_id, event_id=1179, subevents=[subevent])
+
+    await sensor.on_history_replay(event, summary, True)
+
+    assert sensor.extra_state_attributes == {
+        "eventId": 1179,
+        "timestamp": None,
+        "eventTriggerSource": "OUTDOOR_MOTION",
+        "eventClassification": "CONTRABAND",
+        "eventSummary": [
+            {
+                "startFrameIndex": 1,
+                "endFrameIndex": 11,
+                "rfidCode": "958000000000001",
+                "direction": "INWARD",
+                "action": "LOCKED",
+            }
+        ],
+        "rfidCodes": ["958000000000001"],
+    }
+    assert sensor.is_on is False
+    assert "accessToken" not in sensor.extra_state_attributes

--- a/custom_components/onlycat/tests/test_event_store.py
+++ b/custom_components/onlycat/tests/test_event_store.py
@@ -1,5 +1,6 @@
 """Tests for EventStore."""
 
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, call
 
 import pytest
@@ -7,6 +8,16 @@ import pytest
 from custom_components.onlycat.data.event import Event
 from custom_components.onlycat.data.event_store import EventStore
 from custom_components.onlycat.data.event_summary import EventSummary
+
+
+def recovery_event(device_id: str, event_id: int) -> Event:
+    """Build an event from a recent gateway history page."""
+    return Event(
+        device_id=device_id,
+        event_id=event_id,
+        timestamp=datetime(2026, 7, 21, 21, event_id % 60, tzinfo=UTC),
+        access_token=f"token-{event_id}",
+    )
 
 
 @pytest.mark.asyncio
@@ -129,6 +140,67 @@ async def test_history_replay_restores_current_event() -> None:
     await store.restore_history_replay_listeners(device_id)
 
     assert listener.await_args_list == [
-        call(historical_event, historical_summary, True),
-        call(current_event, current_summary, False),
+        call(historical_event, historical_summary, True),  # noqa: FBT003
+        call(current_event, current_summary, False),  # noqa: FBT003
     ]
+
+
+@pytest.mark.asyncio
+async def test_recovery_replays_every_unseen_event_not_only_the_latest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reconnect recovery fills IDs missed before a later live event arrived."""
+    device_id = "OC-00000000001"
+    api_client = AsyncMock()
+    api_client.send_message.side_effect = lambda _topic, data, **_kwargs: {
+        "deviceId": device_id,
+        "eventId": data["eventId"],
+        "subevents": [],
+    }
+    store = EventStore(api_client)
+    listener = AsyncMock()
+    store.add_history_replay_listener(device_id, listener)
+    monkeypatch.setattr(
+        "custom_components.onlycat.data.event_store.RECOVERY_REQUEST_DELAY_SECONDS", 0
+    )
+
+    events = [recovery_event(device_id, event_id) for event_id in range(1330, 1334)]
+    store.mark_events_seen([events[0], events[3]])
+
+    recovered = await store.recover_unseen_events(device_id, events)
+
+    expected_recovered = 2
+    assert recovered == expected_recovered
+    assert [item.args[0].event_id for item in listener.await_args_list] == [1331, 1332]
+    assert [
+        item.kwargs["notify_listeners"]
+        for item in api_client.send_message.await_args_list
+    ] == [False, False]
+
+    listener.reset_mock()
+    assert await store.recover_unseen_events(device_id, events) == 0
+    listener.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_recovery_retries_an_event_until_its_summary_is_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An incomplete gateway summary is not permanently treated as processed."""
+    device_id = "OC-00000000001"
+    event = recovery_event(device_id, 1331)
+    api_client = AsyncMock()
+    api_client.send_message.side_effect = [
+        None,
+        {"deviceId": device_id, "eventId": 1331, "subevents": []},
+    ]
+    store = EventStore(api_client)
+    listener = AsyncMock()
+    store.add_history_replay_listener(device_id, listener)
+    monkeypatch.setattr(
+        "custom_components.onlycat.data.event_store.RECOVERY_REQUEST_DELAY_SECONDS", 0
+    )
+
+    assert await store.recover_unseen_events(device_id, [event]) == 0
+    assert await store.recover_unseen_events(device_id, [event]) == 1
+    listener.assert_awaited_once()

--- a/custom_components/onlycat/tests/test_event_store.py
+++ b/custom_components/onlycat/tests/test_event_store.py
@@ -6,6 +6,7 @@ import pytest
 
 from custom_components.onlycat.data.event import Event
 from custom_components.onlycat.data.event_store import EventStore
+from custom_components.onlycat.data.event_summary import EventSummary
 
 
 @pytest.mark.asyncio
@@ -108,3 +109,26 @@ async def test_run_listeners_never_calls_with_none() -> None:
         # Verify the argument was never None in any call
         for c in listener.call_args_list:
             assert c != call(None), "Listener must never be called with None"
+
+
+@pytest.mark.asyncio
+async def test_history_replay_restores_current_event() -> None:
+    """Historical replay uses isolated listeners and restores the live event."""
+    store = EventStore(AsyncMock())
+    device_id = "OC-00000000001"
+    historical_event = Event(device_id=device_id, event_id=41)
+    historical_summary = EventSummary(device_id=device_id, event_id=41)
+    current_event = Event(device_id=device_id, event_id=42)
+    current_summary = EventSummary(device_id=device_id, event_id=42)
+    listener = AsyncMock()
+    store.add_history_replay_listener(device_id, listener)
+    store._current_events[device_id] = current_event  # noqa: SLF001
+    store._current_summaries[device_id] = current_summary  # noqa: SLF001
+
+    await store.run_history_replay_listeners(historical_event, historical_summary)
+    await store.restore_history_replay_listeners(device_id)
+
+    assert listener.await_args_list == [
+        call(historical_event, historical_summary, True),
+        call(current_event, current_summary, False),
+    ]

--- a/custom_components/onlycat/tests/test_services_backfill.py
+++ b/custom_components/onlycat/tests/test_services_backfill.py
@@ -9,45 +9,46 @@ from custom_components.onlycat.data.event_store import EventStore
 from custom_components.onlycat.services import async_handle_backfill_event_summaries
 
 
-@pytest.mark.asyncio
-async def test_backfill_is_bounded_and_does_not_notify_live_api_listeners(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The manual backfill replays summaries through its isolated listener path."""
-    device_id = "OC-00000000001"
-    event = {
+def make_event(
+    device_id: str,
+    event_id: int,
+    global_id: int,
+    *,
+    access_token: str | None = "ephemeral-token",
+) -> dict:
+    """Build a gateway event response."""
+    return {
+        "globalId": global_id,
         "deviceId": device_id,
-        "eventId": 1179,
-        "timestamp": "2026-07-16T00:19:25+00:00",
+        "eventId": event_id,
+        "timestamp": f"2026-07-16T00:{event_id % 60:02d}:25+00:00",
         "frameCount": 12,
         "eventTriggerSource": 3,
         "eventClassification": 3,
-        "accessToken": "ephemeral-token",
+        "accessToken": access_token,
         "rfidCodes": [],
     }
-    summary = {
+
+
+def make_summary(device_id: str, event_id: int) -> dict:
+    """Build a gateway event-summary response."""
+    return {
         "deviceId": device_id,
-        "eventId": 1179,
+        "eventId": event_id,
         "subevents": [
             {
                 "startFrameIndex": 1,
                 "endFrameIndex": 11,
                 "rfidCode": "958000000000001",
                 "direction": "INWARD",
-                "action": "LOCKED",
+                "action": "DENY",
             }
         ],
     }
 
-    async def send_message(topic: str, _data: dict, **kwargs: bool) -> object:
-        assert kwargs == {"notify_listeners": False}
-        if topic == "getDeviceEvents":
-            return [event]
-        if topic == "getEventSummary":
-            return summary
-        raise AssertionError(f"Unexpected topic: {topic}")
 
-    client = SimpleNamespace(send_message=AsyncMock(side_effect=send_message))
+def make_entry(device_id: str, client: SimpleNamespace) -> tuple[object, AsyncMock]:
+    """Build a minimal config entry and capture its replay listener."""
     store = EventStore(client)
     replay_listener = AsyncMock()
     store.add_history_replay_listener(device_id, replay_listener)
@@ -58,15 +59,42 @@ async def test_backfill_is_bounded_and_does_not_notify_live_api_listeners(
             event_store=store,
         )
     )
-    call = SimpleNamespace(data={"days": 31, "maximum_events": 1})
+    return entry, replay_listener
+
+
+@pytest.mark.asyncio
+async def test_bounded_backfill_uses_only_the_latest_gateway_page(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The default backfill remains bounded and does not paginate."""
+    device_id = "OC-00000000001"
+    event = make_event(device_id, 1179, 2179)
+
+    async def send_message(topic: str, data: dict, **kwargs: bool) -> object:
+        assert kwargs == {"notify_listeners": False}
+        if topic == "getDeviceEvents":
+            assert data == {"deviceId": device_id, "subscribe": False}
+            return [event]
+        if topic == "getEventSummary":
+            return make_summary(device_id, data["eventId"])
+        raise AssertionError(f"Unexpected topic: {topic}")
+
+    client = SimpleNamespace(send_message=AsyncMock(side_effect=send_message))
+    entry, replay_listener = make_entry(device_id, client)
+    call = SimpleNamespace(
+        data={"all_history": False, "days": 31, "maximum_events": 1}
+    )
     monkeypatch.setattr("custom_components.onlycat.services.BACKFILL_DELAY_SECONDS", 0)
 
     result = await async_handle_backfill_event_summaries(call, entry)
 
     assert result == {
+        "pages": 1,
         "listed": 1,
+        "unique_events": 1,
         "eligible": 1,
         "replayed": 1,
+        "summaries": 1,
         "skipped": 0,
         "failed": 0,
     }
@@ -74,4 +102,102 @@ async def test_backfill_is_bounded_and_does_not_notify_live_api_listeners(
     replay_event, replay_summary, historical = replay_listener.await_args.args
     assert replay_event.event_id == 1179
     assert replay_summary.event_id == 1179
+    assert historical is True
+
+
+@pytest.mark.asyncio
+async def test_full_backfill_pages_backwards_and_deduplicates_events(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """All-history mode follows the oldest global ID until an empty page."""
+    device_id = "OC-00000000001"
+    newest = make_event(device_id, 103, 203)
+    overlap = make_event(device_id, 102, 202)
+    oldest = make_event(device_id, 101, 201)
+    page_requests: list[dict] = []
+
+    async def send_message(topic: str, data: dict, **kwargs: bool) -> object:
+        assert kwargs == {"notify_listeners": False}
+        if topic == "getDeviceEvents":
+            page_requests.append(data)
+            before = data.get("beforeGlobalId")
+            if before is None:
+                return [newest, overlap]
+            if before == 202:
+                return [overlap, oldest]
+            if before == 201:
+                return []
+            raise AssertionError(f"Unexpected cursor: {before}")
+        if topic == "getEventSummary":
+            return make_summary(device_id, data["eventId"])
+        raise AssertionError(f"Unexpected topic: {topic}")
+
+    client = SimpleNamespace(send_message=AsyncMock(side_effect=send_message))
+    entry, replay_listener = make_entry(device_id, client)
+    call = SimpleNamespace(data={"all_history": True})
+    monkeypatch.setattr("custom_components.onlycat.services.BACKFILL_DELAY_SECONDS", 0)
+    monkeypatch.setattr(
+        "custom_components.onlycat.services.BACKFILL_PAGE_DELAY_SECONDS", 0
+    )
+
+    result = await async_handle_backfill_event_summaries(call, entry)
+
+    assert page_requests == [
+        {"deviceId": device_id, "subscribe": False},
+        {
+            "deviceId": device_id,
+            "subscribe": False,
+            "beforeGlobalId": 202,
+        },
+        {
+            "deviceId": device_id,
+            "subscribe": False,
+            "beforeGlobalId": 201,
+        },
+    ]
+    assert result == {
+        "pages": 3,
+        "listed": 4,
+        "unique_events": 3,
+        "eligible": 3,
+        "replayed": 3,
+        "summaries": 3,
+        "skipped": 0,
+        "failed": 0,
+    }
+    assert [
+        invocation.args[0].event_id
+        for invocation in replay_listener.await_args_list
+    ] == [101, 102, 103]
+
+
+@pytest.mark.asyncio
+async def test_backfill_preserves_base_event_without_a_summary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An old event remains useful even when its summary token is absent."""
+    device_id = "OC-00000000001"
+    event = make_event(device_id, 1179, 2179, access_token=None)
+
+    async def send_message(topic: str, _data: dict, **kwargs: bool) -> object:
+        assert kwargs == {"notify_listeners": False}
+        if topic == "getDeviceEvents":
+            return [event]
+        raise AssertionError(f"Unexpected topic: {topic}")
+
+    client = SimpleNamespace(send_message=AsyncMock(side_effect=send_message))
+    entry, replay_listener = make_entry(device_id, client)
+    call = SimpleNamespace(
+        data={"all_history": False, "days": 31, "maximum_events": 1}
+    )
+    monkeypatch.setattr("custom_components.onlycat.services.BACKFILL_DELAY_SECONDS", 0)
+
+    result = await async_handle_backfill_event_summaries(call, entry)
+
+    assert result["replayed"] == 1
+    assert result["summaries"] == 0
+    assert result["skipped"] == 1
+    replay_event, replay_summary, historical = replay_listener.await_args.args
+    assert replay_event.event_id == 1179
+    assert replay_summary is None
     assert historical is True

--- a/custom_components/onlycat/tests/test_services_backfill.py
+++ b/custom_components/onlycat/tests/test_services_backfill.py
@@ -14,7 +14,7 @@ def make_event(
     event_id: int,
     global_id: int,
     *,
-    access_token: str | None = "ephemeral-token",
+    access_token: str | None = "ephemeral-token",  # noqa: S107
 ) -> dict:
     """Build a gateway event response."""
     return {
@@ -77,13 +77,12 @@ async def test_bounded_backfill_uses_only_the_latest_gateway_page(
             return [event]
         if topic == "getEventSummary":
             return make_summary(device_id, data["eventId"])
-        raise AssertionError(f"Unexpected topic: {topic}")
+        message = f"Unexpected topic: {topic}"
+        raise AssertionError(message)
 
     client = SimpleNamespace(send_message=AsyncMock(side_effect=send_message))
     entry, replay_listener = make_entry(device_id, client)
-    call = SimpleNamespace(
-        data={"all_history": False, "days": 31, "maximum_events": 1}
-    )
+    call = SimpleNamespace(data={"all_history": False, "days": 31, "maximum_events": 1})
     monkeypatch.setattr("custom_components.onlycat.services.BACKFILL_DELAY_SECONDS", 0)
 
     result = await async_handle_backfill_event_summaries(call, entry)
@@ -100,8 +99,9 @@ async def test_bounded_backfill_uses_only_the_latest_gateway_page(
     }
     replay_listener.assert_awaited_once()
     replay_event, replay_summary, historical = replay_listener.await_args.args
-    assert replay_event.event_id == 1179
-    assert replay_summary.event_id == 1179
+    expected_event_id = 1179
+    assert replay_event.event_id == expected_event_id
+    assert replay_summary.event_id == expected_event_id
     assert historical is True
 
 
@@ -123,14 +123,18 @@ async def test_full_backfill_pages_backwards_and_deduplicates_events(
             before = data.get("beforeGlobalId")
             if before is None:
                 return [newest, overlap]
-            if before == 202:
+            overlap_global_id = 202
+            oldest_global_id = 201
+            if before == overlap_global_id:
                 return [overlap, oldest]
-            if before == 201:
+            if before == oldest_global_id:
                 return []
-            raise AssertionError(f"Unexpected cursor: {before}")
+            message = f"Unexpected cursor: {before}"
+            raise AssertionError(message)
         if topic == "getEventSummary":
             return make_summary(device_id, data["eventId"])
-        raise AssertionError(f"Unexpected topic: {topic}")
+        message = f"Unexpected topic: {topic}"
+        raise AssertionError(message)
 
     client = SimpleNamespace(send_message=AsyncMock(side_effect=send_message))
     entry, replay_listener = make_entry(device_id, client)
@@ -166,8 +170,7 @@ async def test_full_backfill_pages_backwards_and_deduplicates_events(
         "failed": 0,
     }
     assert [
-        invocation.args[0].event_id
-        for invocation in replay_listener.await_args_list
+        invocation.args[0].event_id for invocation in replay_listener.await_args_list
     ] == [101, 102, 103]
 
 
@@ -183,13 +186,12 @@ async def test_backfill_preserves_base_event_without_a_summary(
         assert kwargs == {"notify_listeners": False}
         if topic == "getDeviceEvents":
             return [event]
-        raise AssertionError(f"Unexpected topic: {topic}")
+        message = f"Unexpected topic: {topic}"
+        raise AssertionError(message)
 
     client = SimpleNamespace(send_message=AsyncMock(side_effect=send_message))
     entry, replay_listener = make_entry(device_id, client)
-    call = SimpleNamespace(
-        data={"all_history": False, "days": 31, "maximum_events": 1}
-    )
+    call = SimpleNamespace(data={"all_history": False, "days": 31, "maximum_events": 1})
     monkeypatch.setattr("custom_components.onlycat.services.BACKFILL_DELAY_SECONDS", 0)
 
     result = await async_handle_backfill_event_summaries(call, entry)
@@ -198,6 +200,7 @@ async def test_backfill_preserves_base_event_without_a_summary(
     assert result["summaries"] == 0
     assert result["skipped"] == 1
     replay_event, replay_summary, historical = replay_listener.await_args.args
-    assert replay_event.event_id == 1179
+    expected_event_id = 1179
+    assert replay_event.event_id == expected_event_id
     assert replay_summary is None
     assert historical is True

--- a/custom_components/onlycat/tests/test_services_backfill.py
+++ b/custom_components/onlycat/tests/test_services_backfill.py
@@ -1,0 +1,77 @@
+"""Tests for the OnlyCat historical event-summary backfill."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.onlycat.data.event_store import EventStore
+from custom_components.onlycat.services import async_handle_backfill_event_summaries
+
+
+@pytest.mark.asyncio
+async def test_backfill_is_bounded_and_does_not_notify_live_api_listeners(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The manual backfill replays summaries through its isolated listener path."""
+    device_id = "OC-00000000001"
+    event = {
+        "deviceId": device_id,
+        "eventId": 1179,
+        "timestamp": "2026-07-16T00:19:25+00:00",
+        "frameCount": 12,
+        "eventTriggerSource": 3,
+        "eventClassification": 3,
+        "accessToken": "ephemeral-token",
+        "rfidCodes": [],
+    }
+    summary = {
+        "deviceId": device_id,
+        "eventId": 1179,
+        "subevents": [
+            {
+                "startFrameIndex": 1,
+                "endFrameIndex": 11,
+                "rfidCode": "958000000000001",
+                "direction": "INWARD",
+                "action": "LOCKED",
+            }
+        ],
+    }
+
+    async def send_message(topic: str, _data: dict, **kwargs: bool) -> object:
+        assert kwargs == {"notify_listeners": False}
+        if topic == "getDeviceEvents":
+            return [event]
+        if topic == "getEventSummary":
+            return summary
+        raise AssertionError(f"Unexpected topic: {topic}")
+
+    client = SimpleNamespace(send_message=AsyncMock(side_effect=send_message))
+    store = EventStore(client)
+    replay_listener = AsyncMock()
+    store.add_history_replay_listener(device_id, replay_listener)
+    entry = SimpleNamespace(
+        runtime_data=SimpleNamespace(
+            client=client,
+            devices=[SimpleNamespace(device_id=device_id)],
+            event_store=store,
+        )
+    )
+    call = SimpleNamespace(data={"days": 31, "maximum_events": 1})
+    monkeypatch.setattr("custom_components.onlycat.services.BACKFILL_DELAY_SECONDS", 0)
+
+    result = await async_handle_backfill_event_summaries(call, entry)
+
+    assert result == {
+        "listed": 1,
+        "eligible": 1,
+        "replayed": 1,
+        "skipped": 0,
+        "failed": 0,
+    }
+    replay_listener.assert_awaited_once()
+    replay_event, replay_summary, historical = replay_listener.await_args.args
+    assert replay_event.event_id == 1179
+    assert replay_summary.event_id == 1179
+    assert historical is True


### PR DESCRIPTION
## Summary

This draft addresses event-history fidelity and recovery after transient gateway gaps:

- retain the exact RFID, direction, and action subevents returned by `getEventSummary`
- add a manual, throttled `onlycat.backfill_event_summaries` action, including optional cursor-based full-history replay
- reconnect a dropped or half-connected Socket.IO namespace with bounded exponential backoff and restore subscriptions
- reconcile every unseen event ID from the latest gateway page after reconnecting
- check that page every 15 minutes as a safeguard against silent push gaps

## Motivation

The existing reconnect path hydrates only the newest event. If the WebSocket silently drops events and a later event is delivered, earlier event IDs can remain absent from Home Assistant Recorder indefinitely. That loses transit and contraband history even though the gateway still retains those events.

## Safety and gateway load

- Access tokens are used for summary retrieval but are never exposed as entity attributes.
- Historical replay has a separate listener path and restores the live event afterward, so it does not rewrite current pet location, door policy, or flap state.
- Manual backfill is bounded by default, deduplicates event IDs, detects non-advancing cursors, and sends at most one gateway request per second.
- Automatic reconciliation requests only the latest event page every 15 minutes and fetches summaries only for unseen IDs.
- Successfully handled IDs are retained in a bounded 200-ID set per device.
- Incomplete summaries remain unseen and are retried on a later reconciliation.

The interval and full-history option are intentionally called out for maintainer review because the OnlyCat team can best judge the gateway's preferred load profile and API guarantees.

## Compatibility

The branch is based on current upstream `master` and retains the new API-key setup and persisted pet/device-tracker state. It does not change upstream ownership, repository URLs, manifest version, or changelog.

The work is separated into four logical commits for easier review. I am happy to split it into smaller PRs if preferred.

## Testing

- `ruff format --check .`
- `ruff check .`
- `git diff --check`
- full test suite in `ghcr.io/home-assistant/home-assistant:stable` (Python 3.14.6): **26 passed**

Regression coverage includes a gap where event IDs 1331 and 1332 are missing even though a later ID has already been processed, plus retry behavior when an event summary is temporarily incomplete.
