### PR TITLE
WIP: Fix device_tracker (pet) restore on restart.

### DIFF
--- a/custom_components/onlycat/data/event_store.py
+++ b/custom_components/onlycat/data/event_store.py
@@ -128,6 +128,11 @@ class EventStore:
                     and pet.last_seen_event.event_id == summary.event_id
                 ):
                     pet.last_seen = pet.last_seen_event.timestamp
+                    _LOGGER.debug(
+                        "Updated pet %s last seen time to %s based on event",
+                        pet.rfid_code,
+                        pet.last_seen,
+                    )
                 pet.update_from_subevent(subevent)
                 changed_pets.add(pet.rfid_code)
         for rfid_code in changed_pets:

--- a/custom_components/onlycat/data/event_store.py
+++ b/custom_components/onlycat/data/event_store.py
@@ -128,11 +128,6 @@ class EventStore:
                     and pet.last_seen_event.event_id == summary.event_id
                 ):
                     pet.last_seen = pet.last_seen_event.timestamp
-                    _LOGGER.debug(
-                        "Updated pet %s last seen time to %s based on event",
-                        pet.rfid_code,
-                        pet.last_seen,
-                    )
                 pet.update_from_subevent(subevent)
                 changed_pets.add(pet.rfid_code)
         for rfid_code in changed_pets:

--- a/custom_components/onlycat/data/pet.py
+++ b/custom_components/onlycat/data/pet.py
@@ -47,7 +47,8 @@ class Pet:
             else:
                 self.location = STATE_HOME
         _LOGGER.debug(
-            "Updated pet %s location to %s based on subevent",
+            "Updated pet %s location to %s based on subevent at %s",
             self.rfid_code,
             self.location,
+            self.last_seen
         )

--- a/custom_components/onlycat/data/pet.py
+++ b/custom_components/onlycat/data/pet.py
@@ -50,5 +50,5 @@ class Pet:
             "Updated pet %s location to %s based on subevent at %s",
             self.rfid_code,
             self.location,
-            self.last_seen
+            self.last_seen,
         )

--- a/custom_components/onlycat/device_tracker.py
+++ b/custom_components/onlycat/device_tracker.py
@@ -99,7 +99,6 @@ class OnlyCatPetTracker(TrackerEntity, RestoreEntity):
             restored_last_seen is None or restored_last_seen <= self.pet.last_seen
         ):
             return
-        # TODO: This is only updating the self.pet of this device_tracker. It has to restore the state to the event_store.
         self.pet.location = last_state.state
         self.pet.last_seen = restored_last_seen
         self.pet.last_seen_event = None
@@ -114,12 +113,6 @@ class OnlyCatPetTracker(TrackerEntity, RestoreEntity):
         self.pet = pet
         self._attr_in_zones = ["zone.home"] if pet.location == STATE_HOME else []
         self._attr_last_seen = pet.last_seen
-        _LOGGER.debug(
-            "Pet %s updated location to %s, last seen at %s",
-            pet.rfid_code,
-            pet.location,
-            pet.last_seen,
-        )
         self.async_write_ha_state()
 
     async def manual_update_location(self, location: str) -> None:

--- a/custom_components/onlycat/device_tracker.py
+++ b/custom_components/onlycat/device_tracker.py
@@ -99,6 +99,7 @@ class OnlyCatPetTracker(TrackerEntity, RestoreEntity):
             restored_last_seen is None or restored_last_seen <= self.pet.last_seen
         ):
             return
+        # TODO: This is only updating the self.pet of this device_tracker. It has to restore the state to the event_store.
         self.pet.location = last_state.state
         self.pet.last_seen = restored_last_seen
         self._attr_in_zones = ["zone.home"] if last_state.state == STATE_HOME else []

--- a/custom_components/onlycat/device_tracker.py
+++ b/custom_components/onlycat/device_tracker.py
@@ -112,6 +112,12 @@ class OnlyCatPetTracker(TrackerEntity, RestoreEntity):
         self.pet = pet
         self._attr_in_zones = ["zone.home"] if pet.location == STATE_HOME else []
         self._attr_last_seen = pet.last_seen
+        _LOGGER.debug(
+            "Pet %s updated location to %s, last seen at %s",
+            pet.rfid_code,
+            pet.location,
+            pet.last_seen,
+        )
         self.async_write_ha_state()
 
     async def manual_update_location(self, location: str) -> None:

--- a/custom_components/onlycat/device_tracker.py
+++ b/custom_components/onlycat/device_tracker.py
@@ -129,4 +129,10 @@ class OnlyCatPetTracker(TrackerEntity, RestoreEntity):
         self.pet.last_seen = datetime.now(UTC)
         self._attr_last_seen = self.pet.last_seen
         self._attr_in_zones = ["zone.home"] if location == STATE_HOME else []
+        _LOGGER.debug(
+            "Manually updated pet %s location to %s at %s",
+            self.pet.rfid_code,
+            location,
+            self.pet.last_seen,
+        )
         self.async_write_ha_state()

--- a/custom_components/onlycat/device_tracker.py
+++ b/custom_components/onlycat/device_tracker.py
@@ -102,9 +102,10 @@ class OnlyCatPetTracker(TrackerEntity, RestoreEntity):
         # TODO: This is only updating the self.pet of this device_tracker. It has to restore the state to the event_store.
         self.pet.location = last_state.state
         self.pet.last_seen = restored_last_seen
-        self._attr_in_zones = ["zone.home"] if last_state.state == STATE_HOME else []
-        self._attr_last_seen = restored_last_seen
-        self.async_write_ha_state()
+        self.pet.last_seen_event = None
+        self.pet.last_seen_summary = None
+        self._event_store.add_pet(self.pet)
+        await self._event_store.run_pet_listeners(self.pet.rfid_code)
 
     async def on_pet_update(self, pet: Pet) -> None:
         """Handle updates to the pet data."""


### PR DESCRIPTION
Fixes the restore behavior. Currently only the device_tracker is restored, but with the underlying pet in the event_store not being updated, any recent event will take precedence.